### PR TITLE
Add Acronym exercise and update Meetup

### DIFF
--- a/acronym/README.md
+++ b/acronym/README.md
@@ -1,0 +1,32 @@
+# Acronym
+
+Welcome to Acronym on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name like Portable Network Graphics to its acronym (PNG).
+
+Punctuation is handled as follows: hyphens are word separators (like whitespace); all other punctuation can be removed from the input.
+
+For example:
+
+|Input|Output|
+|-|-|
+|As Soon As Possible|ASAP|
+|Liquid-crystal display|LCD|
+|Thank George It's Friday!|TGIF|
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Julien Vanier - https://github.com/monkbroc

--- a/acronym/acronym.awk
+++ b/acronym/acronym.awk
@@ -1,0 +1,10 @@
+BEGIN {
+    FS = "[^[:alnum:]']"
+    OFS = ""
+}
+{
+    for (i = 1; i <= NF; ++i) {
+        $i = toupper(substr($i, 1, 1))
+    }
+    print
+}

--- a/acronym/acronym.awk
+++ b/acronym/acronym.awk
@@ -1,10 +1,10 @@
 BEGIN {
     FS = "[^[:alnum:]']"
-    OFS = ""
 }
 {
-    for (i = 1; i <= NF; ++i) {
-        $i = toupper(substr($i, 1, 1))
+    acronym = ""
+    for (; NF; --NF) {
+        acronym = substr($NF, 1, 1) acronym
     }
-    print
+    print toupper(acronym)
 }

--- a/acronym/test-acronym.bats
+++ b/acronym/test-acronym.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test 'basic' {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f acronym.awk <<< 'Portable Network Graphics'
+  assert_success
+  assert_output 'PNG'
+}
+
+@test 'lowercase words' {
+  run gawk -f acronym.awk <<< 'Ruby on Rails'
+  assert_success
+  assert_output 'ROR'
+}
+
+@test 'punctuation' {
+  run gawk -f acronym.awk <<< 'First In, First Out'
+  assert_success
+  assert_output 'FIFO'
+}
+
+@test 'all caps word' {
+  run gawk -f acronym.awk <<< 'GNU Image Manipulation Program'
+  assert_success
+  assert_output 'GIMP'
+}
+
+@test 'punctuation without whitespace' {
+  run gawk -f acronym.awk <<< 'Complementary metal-oxide semiconductor'
+  assert_success
+  assert_output 'CMOS'
+}
+
+@test 'very long abbreviation' {
+  run gawk -f acronym.awk <<< 'Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me'
+  assert_success
+  assert_output 'ROTFLSHTMDCOALM'
+}
+
+@test "consecutive delimiters" {
+  run gawk -f acronym.awk <<< "Something - I made up from thin air"
+  assert_success
+  assert_output "SIMUFTA"
+}
+
+@test "apostrophes" {
+  run gawk -f acronym.awk <<< "Halley's Comet"
+  assert_success
+  assert_output "HC"
+}
+
+@test "underscore emphasis" {
+  run gawk -f acronym.awk <<< "The Road __Not__ Taken"
+  assert_success
+  assert_output "TRNT"
+}

--- a/meetup/meetup.awk
+++ b/meetup/meetup.awk
@@ -8,7 +8,7 @@ BEGIN {FS = ","}
 /last/ {print find_date(last_day($1, $2) - 6)}
 
 function weekday(day) {
-    return strftime("%A", mktime(sprintf("%4d %02d %02d 0 0 0", $1, $2, day)))
+    return strftime("%A", mktime($1" "$2" "day" 0 0 0"))
 }
 function find_date(startDay,    day) {
     for (day = startDay + 6; day >= startDay; --day)
@@ -17,5 +17,5 @@ function find_date(startDay,    day) {
 }
 function last_day(year, month) {
     if (++month == 13) {++year; month = 1}
-    return strftime("%d", mktime(year " " month " 01 0 0 0") - 1)
+    return strftime("%d", mktime(year " " month " 1 0 0 0") - 1)
 }


### PR DESCRIPTION
Introduced a new exercise, Acronym, with corresponding README and implementation files. The Acronym exercise aims to convert a phrase to its acronym. Also made minor updates to the Meetup exercise's implementation to refine its date and week processing efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced the Acronym exercise on Exercism's AWK Track, enabling users to convert phrases to acronyms.
    - Updated `acronym.awk` to generate acronyms from input text by converting the first letter of each word to uppercase.
    - Adjusted the `mktime` function calls in the `weekday` and `last_day` functions in the `meetup.awk` script for improved date calculation logic.

- **Documentation**
    - Added detailed README for the Acronym exercise.

- **Tests**
    - Implemented comprehensive tests for the new Acronym functionality, covering various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->