### PR TITLE
Add 'Allergies' exercise to Exercism's AWK track

### DIFF
--- a/allergies/README.md
+++ b/allergies/README.md
@@ -1,0 +1,42 @@
+# Allergies
+
+Welcome to Allergies on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
+An allergy test produces a single numeric score which contains the information about all the allergies the person has (that they were tested for).
+
+The list of items (and their value) that were tested are:
+
+- eggs (1)
+- peanuts (2)
+- shellfish (4)
+- strawberries (8)
+- tomatoes (16)
+- chocolate (32)
+- pollen (64)
+- cats (128)
+
+So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
+
+Now, given just that score of 34, your program should be able to say:
+
+- Whether Tom is allergic to any one of those allergens listed above.
+- All the allergens Tom is allergic to.
+
+Note: a given score may include allergens **not** listed above (i.e.  allergens that score 256, 512, 1024, etc.).
+Your program should ignore those components of the score.
+For example, if the allergy score is 257, your program should only report the eggs (1) allergy.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Exercise by the JumpstartLab team for students at The Turing School of Software and Design. - https://turing.edu

--- a/allergies/allergies.awk
+++ b/allergies/allergies.awk
@@ -1,0 +1,36 @@
+BEGIN {
+    OFS = FS = ","
+    Items["eggs"] = 1
+    Items["peanuts"] = 2
+    Items["shellfish"] = 4
+    Items["strawberries"] = 8
+    Items["tomatoes"] = 16
+    Items["chocolate"] = 32
+    Items["pollen"] = 64
+    Items["cats"] = 128
+}
+{
+    score = $1 % 256
+}
+/allergic_to/ {
+    print isAlegric(score, Items[$3]) ? "true" : "false"
+}
+/list/ {
+    NF = 0
+    for (i = 1; i <= 128; i *= 2)
+        if (isAlegric(score, i))
+            $(++NF) = itemName(i)
+    print
+}
+
+function isAlegric(score, item,   i) {
+    for (i = 128; i > item; i /= 2)
+        if (score >= i) score -= i
+    return score >= item
+}
+
+function itemName(score,   name) {
+    for (name in Items)
+        if (Items[name] == score)
+            return name
+}

--- a/allergies/allergies.awk
+++ b/allergies/allergies.awk
@@ -13,20 +13,18 @@ BEGIN {
     score = $1 % 256
 }
 /allergic_to/ {
-    print isAlegric(score, Items[$3]) ? "true" : "false"
+    print isAllegric(score, Items[$3]) ? "true" : "false"
 }
 /list/ {
     NF = 0
     for (i = 1; i <= 128; i *= 2)
-        if (isAlegric(score, i))
+        if (isAllegric(score, i))
             $(++NF) = itemName(i)
     print
 }
 
-function isAlegric(score, item,   i) {
-    for (i = 128; i > item; i /= 2)
-        if (score >= i) score -= i
-    return score >= item
+function isAllegric(score, item) {
+    return and(score, item) == item
 }
 
 function itemName(score,   name) {

--- a/allergies/test-allergies.bats
+++ b/allergies/test-allergies.bats
@@ -1,0 +1,283 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test 'eggs: not allergic to anything' {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '0,allergic_to,eggs'
+    assert_success
+    assert_output "false"
+}
+@test 'eggs: allergic only to eggs' {
+    run gawk -f allergies.awk <<< '1,allergic_to,eggs'
+    assert_success
+    assert_output "true"
+}
+@test 'eggs: allergic to eggs and something else' {
+    run gawk -f allergies.awk <<< '3,allergic_to,eggs'
+    assert_success
+    assert_output "true"
+}
+@test 'eggs: allergic to something, but not eggs' {
+    run gawk -f allergies.awk <<< '2,allergic_to,eggs'
+    assert_success
+    assert_output "false"
+}
+@test 'eggs: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,eggs'
+    assert_success
+    assert_output "true"
+}
+
+@test 'peanuts: not allergic to anything' {
+    run gawk -f allergies.awk <<< '0,allergic_to,peanuts'
+    assert_success
+    assert_output "false"
+}
+@test 'peanuts: allergic only to peanuts' {
+    run gawk -f allergies.awk <<< '2,allergic_to,peanuts'
+    assert_success
+    assert_output "true"
+}
+@test 'peanuts: allergic to peanuts and something else' {
+    run gawk -f allergies.awk <<< '7,allergic_to,peanuts'
+    assert_success
+    assert_output "true"
+}
+@test 'peanuts: allergic to something, but not peanuts' {
+    run gawk -f allergies.awk <<< '5,allergic_to,peanuts'
+    assert_success
+    assert_output "false"
+}
+@test 'peanuts: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,peanuts'
+    assert_success
+    assert_output "true"
+}
+
+@test 'shellfish: not allergic to anything' {
+    run gawk -f allergies.awk <<< '0,allergic_to,shellfish'
+    assert_success
+    assert_output "false"
+}
+@test 'shellfish: allergic only to shellfish' {
+    run gawk -f allergies.awk <<< '4,allergic_to,shellfish'
+    assert_success
+    assert_output "true"
+}
+@test 'shellfish: allergic to shellfish and something else' {
+    run gawk -f allergies.awk <<< '14,allergic_to,shellfish'
+    assert_success
+    assert_output "true"
+}
+@test 'shellfish: allergic to something, but not shellfish' {
+    run gawk -f allergies.awk <<< '10,allergic_to,shellfish'
+    assert_success
+    assert_output "false"
+}
+@test 'shellfish: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,shellfish'
+    assert_success
+    assert_output "true"
+}
+
+@test 'strawberries: not allergic to anything' {
+    run gawk -f allergies.awk <<< '0,allergic_to,strawberries'
+    assert_success
+    assert_output "false"
+}
+@test 'strawberries: allergic only to strawberries' {
+    run gawk -f allergies.awk <<< '8,allergic_to,strawberries'
+    assert_success
+    assert_output "true"
+}
+@test 'strawberries: allergic to strawberries and something else' {
+    run gawk -f allergies.awk <<< '28,allergic_to,strawberries'
+    assert_success
+    assert_output "true"
+}
+@test 'strawberries: allergic to something, but not strawberries' {
+    run gawk -f allergies.awk <<< '20,allergic_to,strawberries'
+    assert_success
+    assert_output "false"
+}
+@test 'strawberries: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,strawberries'
+    assert_success
+    assert_output "true"
+}
+
+@test 'tomatoes: not allergic to anything' {
+    run gawk -f allergies.awk <<< '0,allergic_to,tomatoes'
+    assert_success
+    assert_output "false"
+}
+@test 'tomatoes: allergic only to tomatoes' {
+    run gawk -f allergies.awk <<< '16,allergic_to,tomatoes'
+    assert_success
+    assert_output "true"
+}
+@test 'tomatoes: allergic to tomatoes and something else' {
+    run gawk -f allergies.awk <<< '56,allergic_to,tomatoes'
+    assert_success
+    assert_output "true"
+}
+@test 'tomatoes: allergic to something, but not tomatoes' {
+    run gawk -f allergies.awk <<< '40,allergic_to,tomatoes'
+    assert_success
+    assert_output "false"
+}
+@test 'tomatoes: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,tomatoes'
+    assert_success
+    assert_output "true"
+}
+
+@test 'chocolate: not allergic to anything' {
+    run gawk -f allergies.awk <<< '0,allergic_to,chocolate'
+    assert_success
+    assert_output "false"
+}
+@test 'chocolate: allergic only to chocolate' {
+    run gawk -f allergies.awk <<< '32,allergic_to,chocolate'
+    assert_success
+    assert_output "true"
+}
+@test 'chocolate: allergic to chocolate and something else' {
+    run gawk -f allergies.awk <<< '112,allergic_to,chocolate'
+    assert_success
+    assert_output "true"
+}
+@test 'chocolate: allergic to something, but not chocolate' {
+    run gawk -f allergies.awk <<< '80,allergic_to,chocolate'
+    assert_success
+    assert_output "false"
+}
+@test 'chocolate: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,chocolate'
+    assert_success
+    assert_output "true"
+}
+
+@test 'pollen: not allergic to anything' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '0,allergic_to,pollen'
+    assert_success
+    assert_output "false"
+}
+@test 'pollen: allergic only to pollen' {
+    run gawk -f allergies.awk <<< '64,allergic_to,pollen'
+    assert_success
+    assert_output "true"
+}
+@test 'pollen: allergic to pollen and something else' {
+    run gawk -f allergies.awk <<< '224,allergic_to,pollen'
+    assert_success
+    assert_output "true"
+}
+@test 'pollen: allergic to something, but not pollen' {
+    run gawk -f allergies.awk <<< '160,allergic_to,pollen'
+    assert_success
+    assert_output "false"
+}
+@test 'pollen: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,pollen'
+    assert_success
+    assert_output "true"
+}
+
+@test 'cats: not allergic to anything' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '0,allergic_to,cats'
+    assert_success
+    assert_output "false"
+}
+@test 'cats: allergic only to cats' {
+    run gawk -f allergies.awk <<< '128,allergic_to,cats'
+    assert_success
+    assert_output "true"
+}
+@test 'cats: allergic to cats and something else' {
+    run gawk -f allergies.awk <<< '192,allergic_to,cats'
+    assert_success
+    assert_output "true"
+}
+@test 'cats: allergic to something, but not cats' {
+    run gawk -f allergies.awk <<< '64,allergic_to,cats'
+    assert_success
+    assert_output "false"
+}
+@test 'cats: allergic to everything' {
+    run gawk -f allergies.awk <<< '255,allergic_to,cats'
+    assert_success
+    assert_output "true"
+}
+
+@test 'no_allergies_at_all' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '0,list'
+    assert_success
+    refute_output   # no output
+}
+
+@test 'allergic_to_just_eggs' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '1,list'
+    assert_success
+    assert_output "eggs"
+}
+
+@test 'allergic_to_just_peanuts' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '2,list'
+    assert_success
+    assert_output "peanuts"
+}
+
+@test 'allergic_to_just_strawberries' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '8,list'
+    assert_success
+    assert_output "strawberries"
+}
+
+@test 'allergic_to_eggs_and_peanuts' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '3,list'
+    assert_success
+    assert_output "eggs,peanuts"
+}
+
+@test 'allergic_to_more_than_eggs_but_not_peanuts' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '5,list'
+    assert_success
+    assert_output "eggs,shellfish"
+}
+
+@test 'allergic_to_lots_of_stuff' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '248,list'
+    assert_success
+    assert_output "strawberries,tomatoes,chocolate,pollen,cats"
+}
+
+@test 'allergic_to_everything' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '255,list'
+    assert_success
+    assert_output "eggs,peanuts,shellfish,strawberries,tomatoes,chocolate,pollen,cats"
+}
+
+@test 'ignore_non_allergen_score_parts' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '509,list'
+    assert_success
+    assert_output "eggs,shellfish,strawberries,tomatoes,chocolate,pollen,cats"
+}
+
+@test 'no allergen score parts without highest valid score' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f allergies.awk <<< '257,list'
+    assert_success
+    assert_output "eggs"
+}

--- a/allergies/test-allergies.bats
+++ b/allergies/test-allergies.bats
@@ -159,7 +159,6 @@ load bats-extra
 }
 
 @test 'pollen: not allergic to anything' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '0,allergic_to,pollen'
     assert_success
     assert_output "false"
@@ -186,7 +185,6 @@ load bats-extra
 }
 
 @test 'cats: not allergic to anything' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '0,allergic_to,cats'
     assert_success
     assert_output "false"
@@ -213,70 +211,60 @@ load bats-extra
 }
 
 @test 'no_allergies_at_all' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '0,list'
     assert_success
     refute_output   # no output
 }
 
 @test 'allergic_to_just_eggs' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '1,list'
     assert_success
     assert_output "eggs"
 }
 
 @test 'allergic_to_just_peanuts' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '2,list'
     assert_success
     assert_output "peanuts"
 }
 
 @test 'allergic_to_just_strawberries' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '8,list'
     assert_success
     assert_output "strawberries"
 }
 
 @test 'allergic_to_eggs_and_peanuts' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '3,list'
     assert_success
     assert_output "eggs,peanuts"
 }
 
 @test 'allergic_to_more_than_eggs_but_not_peanuts' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '5,list'
     assert_success
     assert_output "eggs,shellfish"
 }
 
 @test 'allergic_to_lots_of_stuff' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '248,list'
     assert_success
     assert_output "strawberries,tomatoes,chocolate,pollen,cats"
 }
 
 @test 'allergic_to_everything' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '255,list'
     assert_success
     assert_output "eggs,peanuts,shellfish,strawberries,tomatoes,chocolate,pollen,cats"
 }
 
 @test 'ignore_non_allergen_score_parts' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '509,list'
     assert_success
     assert_output "eggs,shellfish,strawberries,tomatoes,chocolate,pollen,cats"
 }
 
 @test 'no allergen score parts without highest valid score' {
-    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run gawk -f allergies.awk <<< '257,list'
     assert_success
     assert_output "eggs"


### PR DESCRIPTION
This commit integrates the 'Allergies' exercise into Exercism's AWK track. It introduces a new file containing the problem scenario in a README, an AWK file for the main implementation, and extensive unit tests in a bats file. This addition allows users to learn and practice determining allergies based on a single numeric allergy score.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the Allergies exercise, enabling users to determine allergies based on a numeric score system.
- **Documentation**
	- Added documentation for the Allergies exercise on the AWK Track.
- **Tests**
	- Implemented test cases to verify allergic reactions to various substances like eggs, peanuts, and more, based on input scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->