### PR TITLE
Add Anagram exercise with AWK track and tests

### DIFF
--- a/anagram/README.md
+++ b/anagram/README.md
@@ -1,0 +1,28 @@
+# Anagram
+
+Welcome to Anagram on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
+
+Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Inspired by the Extreme Startup game - https://github.com/rchatley/extreme_startup

--- a/anagram/anagram.awk
+++ b/anagram/anagram.awk
@@ -1,0 +1,19 @@
+# These variables are initialized on the command line (using '-v'):
+# - key
+
+BEGIN {
+    Word = toupper(key)
+    split(Word, Letters, //)
+}
+
+isCandidate() && isAnagram()
+
+function isCandidate() {
+    return length($0) == length(Word) && toupper($0) != Word
+}
+
+function isAnagram(   candidate,i) {
+    candidate = toupper($0)
+    for (i in Letters) sub(Letters[i], "", candidate)
+    return !candidate
+}

--- a/anagram/test-anagram.bats
+++ b/anagram/test-anagram.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "no matches" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=diaper <<WORD_LIST
+hello
+world
+zombies
+pants
+WORD_LIST
+
+    assert_success
+    refute_output     # no output
+}
+
+@test "detects two anagrams" {
+
+    run gawk -f anagram.awk -v key=solemn <<WORD_LIST
+lemons
+cherry
+melons
+WORD_LIST
+
+    assert_success
+    assert_line "lemons"
+    assert_line "melons"
+    assert_equal ${#lines[@]} 2   # output has just 2 lines
+}
+
+@test "does not detect anagram subsets" {
+
+    run gawk -f anagram.awk -v key=good <<WORD_LIST
+dog
+goody
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "detects anagram" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=listen <<WORD_LIST
+enlists
+google
+inlets
+banana
+WORD_LIST
+
+    assert_success
+    assert_line "inlets"
+    assert_equal ${#lines[@]} 1
+}
+
+@test "detects three anagrams" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=allergy <<WORD_LIST
+gallery
+ballerina
+regally
+clergy
+largely
+leading
+WORD_LIST
+
+    assert_success
+    assert_line "gallery"
+    assert_line "regally"
+    assert_line "largely"
+    assert_equal ${#lines[@]} 3
+}
+
+@test "detects multiple anagrams with different case" {
+
+    run gawk -f anagram.awk -v key=nose <<WORD_LIST
+Eons
+ONES
+WORD_LIST
+
+    assert_success
+    assert_line "Eons"
+    assert_line "ONES"
+    assert_equal ${#lines[@]} 2
+}
+
+@test "does not detect non-anagrams with identical checksum" {
+
+    run gawk -f anagram.awk -v key=mass <<WORD_LIST
+last
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "detects anagrams case-insensitively" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=Orchestra <<WORD_LIST
+cashregister
+Carthorse
+radishes
+WORD_LIST
+
+    assert_success
+    assert_line "Carthorse"
+    assert_equal ${#lines[@]} 1
+}
+
+@test "detects anagrams using case-insensitive subject" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=Orchestra <<WORD_LIST
+cashregister
+carthorse
+radishes
+WORD_LIST
+
+    assert_success
+    assert_line "carthorse"
+    assert_equal ${#lines[@]} 1
+}
+
+@test "detects anagrams using case-insensitive possible matches" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=orchestra <<WORD_LIST
+cashregister
+Carthorse
+radishes
+WORD_LIST
+
+    assert_success
+    assert_line "Carthorse"
+    assert_equal ${#lines[@]} 1
+}
+
+@test "does not detect a anagram if the original word is repeated" {
+
+    run gawk -f anagram.awk -v key=go <<WORD_LIST
+go
+Go
+GO
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "anagrams must use all letters exactly once" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=tapper <<WORD_LIST
+patter
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "words are not anagrams of themselves" {
+
+    run gawk -f anagram.awk -v key=BANANA <<WORD_LIST
+BANANA
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "words are not anagrams of themselves even if letter case is partially different" {
+
+    run gawk -f anagram.awk -v key=BANANA <<WORD_LIST
+Banana
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "words are not anagrams of themselves even if letter case is completely different" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=BANANA <<WORD_LIST
+banana
+WORD_LIST
+
+    assert_success
+    refute_output
+}
+
+@test "words other than themselves can be anagrams" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f anagram.awk -v key=LISTEN <<WORD_LIST
+LISTEN
+Silent
+WORD_LIST
+
+    assert_success
+    assert_line "Silent"
+    assert_equal ${#lines[@]} 1
+}


### PR DESCRIPTION
This commit includes a new file for the Anagram exercise in Exercism's AWK track, outlining the requirements of the exercise and an initial implementation. The new anagram script uses command line initialization and AWK functions to determine anagrams. It also adds a substantial battery of tests in a 'test-anagram.bats' file, ensuring that the exercise is well-covered with checks for various edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an anagram detection feature to identify anagrams of a specified key word.
- **Documentation**
	- Added guidelines and examples for determining anagrams in the README.
- **Tests**
	- Implemented test cases for verifying the correct identification of anagrams, including case sensitivity and rule adherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->