### PR TITLE
Add Armstrong Numbers exercise and implement its tests

### DIFF
--- a/armstrong-numbers/README.md
+++ b/armstrong-numbers/README.md
@@ -1,0 +1,29 @@
+# Armstrong Numbers
+
+Welcome to Armstrong Numbers on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+For example:
+
+- 9 is an Armstrong number, because `9 = 9^1 = 9`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 1`
+- 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
+- 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
+
+Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Wikipedia - https://en.wikipedia.org/wiki/Narcissistic_number

--- a/armstrong-numbers/armstrong-numbers.awk
+++ b/armstrong-numbers/armstrong-numbers.awk
@@ -2,7 +2,7 @@
 # - num
 
 BEGIN {
-    print isAmstrong(num) ? "true" : "false"
+    print isArmstrong(num) ? "true" : "false"
 }
 
 function isArmstrong(number,   power,sum,i) {

--- a/armstrong-numbers/armstrong-numbers.awk
+++ b/armstrong-numbers/armstrong-numbers.awk
@@ -1,0 +1,13 @@
+# These variables are initialized on the command line (using '-v'):
+# - num
+
+BEGIN {
+    print isAmstrong(num) ? "true" : "false"
+}
+
+function isAmstrong(number,   power,sum,i) {
+    power = length(number)
+    for (i = power; i > 0; --i)
+        sum += substr(number, i, 1) ^ power
+    return number == sum
+}

--- a/armstrong-numbers/armstrong-numbers.awk
+++ b/armstrong-numbers/armstrong-numbers.awk
@@ -5,7 +5,7 @@ BEGIN {
     print isAmstrong(num) ? "true" : "false"
 }
 
-function isAmstrong(number,   power,sum,i) {
+function isArmstrong(number,   power,sum,i) {
     power = length(number)
     for (i = power; i > 0; --i)
         sum += substr(number, i, 1) ^ power

--- a/armstrong-numbers/test-armstrong-numbers.bats
+++ b/armstrong-numbers/test-armstrong-numbers.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test 'Zero is Armstrong numbers' {
+  # [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f armstrong-numbers.awk -v num=0
+  assert_success
+  assert_output "true"
+}
+
+@test 'Single digits are Armstrong numbers' {
+  run gawk -f armstrong-numbers.awk -v num=5
+  assert_success
+  assert_output "true"
+}
+
+@test 'There are no two digit Armstrong numbers' {
+  run gawk -f armstrong-numbers.awk -v num=10
+  assert_success
+  assert_output "false"
+}
+
+@test 'A three digit number that is an Armstrong number' {
+  run gawk -f armstrong-numbers.awk -v num=153
+  assert_success
+  assert_output "true"
+}
+
+@test 'A three digit number that is not an Armstrong number' {
+  run gawk -f armstrong-numbers.awk -v num=100
+  assert_success
+  assert_output "false"
+}
+
+@test 'A four digit number that is an Armstrong number' {
+  run gawk -f armstrong-numbers.awk -v num=9474
+  assert_success
+  assert_output "true"
+}
+
+@test 'A four digit number that is not an Armstrong number' {
+  run gawk -f armstrong-numbers.awk -v num=9475
+  assert_success
+  assert_output "false"
+}
+
+@test 'A seven digit number that is an Armstrong number' {
+  run gawk -f armstrong-numbers.awk -v num=9926315
+  assert_success
+  assert_output "true"
+}
+
+@test 'A seven digit number that is not an Armstrong number' {
+  run gawk -f armstrong-numbers.awk -v num=9926314
+  assert_success
+  assert_output "false"
+}
+
+# The next 2 tests require the -M option to handle big numbers.
+# Refer to the instructions of the Grains exercise:
+#   https://exercism.org/tracks/awk/exercises/grains
+
+@test "Armstrong number containing seven zeroes" {
+  run gawk -M -f armstrong-numbers.awk -v num=186709961001538790100634132976990
+  assert_success
+  assert_output "true"
+}
+
+@test "The largest and last Armstrong number" {
+  run gawk -M -f armstrong-numbers.awk -v num=115132219018763992565095597973971522401
+  assert_success
+  assert_output "true"
+}


### PR DESCRIPTION
A new exercise titled 'Armstrong Numbers' has been added to the Exercism's AWK track. It also includes an Armstrong Numbers script using AWK functions to determine if a number is an Armstrong number. An extensive list of test cases has been added in a 'test-armstrong-numbers.bats' file to validate various scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new lesson on Armstrong Numbers on the AWK Track, including:
		- Explanation and examples of Armstrong Numbers.
		- A function to check if a given number is an Armstrong number.
		- Comprehensive test cases to ensure accurate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->