### PR TITLE
Add Atbash Cipher exercise

### DIFF
--- a/atbash-cipher/README.md
+++ b/atbash-cipher/README.md
@@ -1,0 +1,42 @@
+# Atbash Cipher
+
+Welcome to Atbash Cipher on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards.
+The first letter is replaced with the last letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is a simple mono-alphabetic substitution cipher.
+However, this may not have been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size being 5 letters, leaving numbers unchanged, and punctuation is excluded.
+This is to make it harder to guess things based on word boundaries.
+All text will be encoded as lowercase letters.
+
+## Examples
+
+- Encoding `test` gives `gvhg`
+- Encoding `x123 yes` gives `c123b vh`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+Wikipedia - https://en.wikipedia.org/wiki/Atbash

--- a/atbash-cipher/atbash-cipher.awk
+++ b/atbash-cipher/atbash-cipher.awk
@@ -1,0 +1,26 @@
+# These variables are initialized on the command line (using '-v'):
+# -direction
+
+BEGIN {
+    FPAT = "[[:alnum:]]"
+    Plain = "abcdefghijklmnopqrstuvwxyz"
+    Cipher = "zyxwvutsrqponmlkjihgfedcba"
+}
+{
+    @direction()
+}
+
+function encode(   i,out,symbol) {
+    for (i = 0; i < NF; out = out symbol) {
+        out = out (i++ % 5 || i == 1 ? "" : " ")
+        symbol = $i ~ /[[:digit:]]/ ? $i : substr(Cipher, index(Plain, tolower($i)), 1)
+    }
+    print out
+}
+
+function decode(   i,out,symbol) {
+    for (i = 0; i++ < NF; out = out symbol) {
+        symbol = $i ~ /[[:digit:]]/ ? $i : substr(Plain, index(Cipher, tolower($i)), 1)
+    }
+    print out
+}

--- a/atbash-cipher/test-atbash-cipher.bats
+++ b/atbash-cipher/test-atbash-cipher.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# local version: 1.2.0.0
+
+# encode
+
+@test "encode yes" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "yes"
+  assert_success
+  assert_output "bvh"
+}
+
+@test "encode no" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "no"
+  assert_success
+  assert_output "ml"
+}
+
+@test "encode OMG" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "OMG"
+  assert_success
+  assert_output "lnt"
+}
+
+@test "encode spaces" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "O M G"
+  assert_success
+  assert_output "lnt"
+}
+
+@test "encode mindblowingly" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "mindblowingly"
+  assert_success
+  assert_output "nrmwy oldrm tob"
+}
+
+@test "encode numbers" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "Testing,1 2 3, testing."
+  assert_success
+  assert_output "gvhgr mt123 gvhgr mt"
+}
+
+@test "encode deep thought" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "Truth is fiction."
+  assert_success
+  assert_output "gifgs rhurx grlm"
+}
+
+@test "encode all the letters" {
+  run gawk -f atbash-cipher.awk -v direction=encode <<< "The quick brown fox jumps over the lazy dog."
+  assert_success
+  assert_output "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+}
+
+# decode
+
+@test "decode exercism" {
+  run gawk -f atbash-cipher.awk -v direction=decode <<< "vcvix rhn"
+  assert_success
+  assert_output "exercism"
+}
+
+@test "decode a sentence" {
+  run gawk -f atbash-cipher.awk -v direction=decode <<< "zmlyh gzxov rhlug vmzhg vkkrm thglm v"
+  assert_success
+  assert_output "anobstacleisoftenasteppingstone"
+}
+
+@test "decode numbers" {
+  run gawk -f atbash-cipher.awk -v direction=decode <<< "gvhgr mt123 gvhgr mt"
+  assert_success
+  assert_output "testing123testing"
+}
+
+@test "decode all the letters" {
+  run gawk -f atbash-cipher.awk -v direction=decode <<< "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+  assert_success
+  assert_output "thequickbrownfoxjumpsoverthelazydog"
+}
+
+@test "decode with too many spaces" {
+  run gawk -f atbash-cipher.awk -v direction=decode <<< "vc vix    r hn"
+  assert_success
+  assert_output "exercism"
+}
+
+@test "decode with no spaces" {
+  run gawk -f atbash-cipher.awk -v direction=decode <<< "zmlyhgzxovrhlugvmzhgvkkrmthglmv"
+  assert_success
+  assert_output "anobstacleisoftenasteppingstone"
+}


### PR DESCRIPTION
This commit introduces a new exercise, the Atbash Cipher, an ancient encryption system. The exercise consists of implementing encoding and decoding functions in AWK language and includes a testing set written in BATS. The cipher relies on a simple letter substitution, where each letter is replaced by the equivalent position letter from the end of the alphabet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the Atbash Cipher, an ancient encryption technique, with a guide on how to implement and utilize it.
	- Added an AWK script for encoding and decoding text using the Atbash Cipher.
- **Documentation**
	- Published a comprehensive README with instructions and examples for the Atbash Cipher.
- **Tests**
	- Implemented test cases to ensure accurate encoding and decoding using the Atbash Cipher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->