### PR TITLE
Add OCR-numbers feature with tests and README

### DIFF
--- a/ocr-numbers/README.md
+++ b/ocr-numbers/README.md
@@ -1,0 +1,94 @@
+# Ocr Numbers
+
+Welcome to Ocr Numbers on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.
+
+## Step One
+
+To begin with, convert a simple binary font to a string containing 0 or 1.
+
+The binary font uses pipes and underscores, four rows high and three columns wide.
+
+```text
+     _   #
+    | |  # zero.
+    |_|  #
+         # the fourth row is always blank
+```
+
+Is converted to "0"
+
+```text
+         #
+      |  # one.
+      |  #
+         # (blank fourth row)
+```
+
+Is converted to "1"
+
+If the input is the correct size, but not recognizable, your program should return '?'
+
+If the input is the incorrect size, your program should return an error.
+
+## Step Two
+
+Update your program to recognize multi-character binary strings, replacing garbled numbers with ?
+
+## Step Three
+
+Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
+
+```text
+ _
+ _|
+|_
+
+```
+
+Is converted to "2"
+
+```text
+      _  _     _  _  _  _  _  _  #
+    | _| _||_||_ |_   ||_||_|| | # decimal numbers.
+    ||_  _|  | _||_|  ||_| _||_| #
+                                 # fourth line is always blank
+```
+
+Is converted to "1234567890"
+
+## Step Four
+
+Update your program to handle multiple numbers, one per line.
+When converting several lines, join the lines with commas.
+
+```text
+    _  _
+  | _| _|
+  ||_  _|
+
+    _  _
+|_||_ |_
+  | _||_|
+
+ _  _  _
+  ||_||_|
+  ||_| _|
+
+```
+
+Is converted to "123,456,789".
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Inspired by the Bank OCR kata - https://codingdojo.org/kata/BankOCR/

--- a/ocr-numbers/ocr-numbers.awk
+++ b/ocr-numbers/ocr-numbers.awk
@@ -1,0 +1,44 @@
+BEGIN {
+    RS = ""
+    FS = "\n"
+    DigitWidth = 3
+    DigitHight = 4
+}
+NF % DigitHight {
+    die("Number of input lines is not a multiple of four")
+}
+length($1) % DigitWidth {
+    die("Number of input columns is not a multiple of three")
+}
+{
+    print number()
+}
+
+function number(   col,row,result) {
+    for (row = 1; row < NF; row += 4) {
+        if (row > 1) result = result","
+        for (col = 1; col < length($row); col += DigitWidth)
+            result = result digit(row, col)
+    }
+    return result
+}
+
+function digit(row, col,   text) {
+    text = cut(row, col) cut(row + 1, col) cut(row + 2, col)
+    switch (text) {
+        case " _ | ||_|": return 0
+        case "     |  |": return 1
+        case " _  _||_ ": return 2
+        case " _  _| _|": return 3
+        case "   |_|  |": return 4
+        case " _ |_  _|": return 5
+        case " _ |_ |_|": return 6
+        case " _   |  |": return 7
+        case " _ |_||_|": return 8
+        case " _ |_| _|": return 9
+        default: return "?"
+    }
+}
+
+function cut(line, i) {return substr($line, i, DigitWidth)}
+function die(message) {print message > "/dev/stderr"; exit 1}

--- a/ocr-numbers/ocr-numbers.awk
+++ b/ocr-numbers/ocr-numbers.awk
@@ -2,9 +2,9 @@ BEGIN {
     RS = ""
     FS = "\n"
     DigitWidth = 3
-    DigitHight = 4
+    DigitHeight = 4
 }
-NF % DigitHight {
+NF % DigitHeight {
     die("Number of input lines is not a multiple of four")
 }
 length($1) % DigitWidth {
@@ -15,7 +15,7 @@ length($1) % DigitWidth {
 }
 
 function number(   col,row,result) {
-    for (row = 1; row < NF; row += 4) {
+    for (row = 1; row < NF; row += DigitHeight) {
         if (row > 1) result = result","
         for (col = 1; col < length($row); col += DigitWidth)
             result = result digit(row, col)

--- a/ocr-numbers/test-ocr-numbers.bats
+++ b/ocr-numbers/test-ocr-numbers.bats
@@ -1,0 +1,204 @@
+#!/usr/bin/env bats
+load bats-extra
+
+
+@test "No input" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f ocr-numbers.awk /dev/null
+    assert_success
+    assert_output ""
+}
+
+@test "Recognizes 0" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+| |
+|_|
+   
+INPUT
+    assert_success
+    assert_output "0"
+}
+
+@test "Recognizes 1" {
+    run gawk -f ocr-numbers.awk << INPUT
+   
+  |
+  |
+   
+INPUT
+    assert_success
+    assert_output "1"
+}
+
+@test "Unreadable but correctly sized inputs return ?" {
+    run gawk -f ocr-numbers.awk << INPUT
+   
+  _
+  |
+   
+INPUT
+    assert_success
+    assert_output "?"
+}
+
+@test "Input with a number of lines that is not a multiple of four raises an error" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+| |
+   
+INPUT
+    assert_failure
+    assert_output "Number of input lines is not a multiple of four"
+}
+
+@test "Input with a number of columns that is not a multiple of three raises an error" {
+    run gawk -f ocr-numbers.awk << INPUT
+    
+   |
+   |
+    
+INPUT
+    assert_failure
+    assert_output "Number of input columns is not a multiple of three"
+}
+
+@test "Recognizes 110101100" {
+    run gawk -f ocr-numbers.awk << INPUT
+       _     _        _  _ 
+  |  || |  || |  |  || || |
+  |  ||_|  ||_|  |  ||_||_|
+                           
+INPUT
+    assert_success
+    assert_output "110101100"
+}
+
+@test "Garbled numbers in a string are replaced with ?" {
+    run gawk -f ocr-numbers.awk << INPUT
+       _     _           _ 
+  |  || |  || |     || || |
+  |  | _|  ||_|  |  ||_||_|
+                           
+INPUT
+    assert_success
+    assert_output "11?10?1?0"
+}
+
+@test "Recognizes 2" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+ _|
+|_ 
+   
+INPUT
+    assert_success
+    assert_output "2"
+}
+
+@test "Recognizes 3" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+ _|
+ _|
+   
+INPUT
+    assert_success
+    assert_output "3"
+}
+
+@test "Recognizes 4" {
+    run gawk -f ocr-numbers.awk << INPUT
+   
+|_|
+  |
+   
+INPUT
+    assert_success
+    assert_output "4"
+}
+
+@test "Recognizes 5" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+|_ 
+ _|
+   
+INPUT
+    assert_success
+    assert_output "5"
+}
+
+@test "Recognizes 6" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+|_ 
+|_|
+   
+INPUT
+    assert_success
+    assert_output "6"
+}
+
+@test "Recognizes 7" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+  |
+  |
+   
+INPUT
+    assert_success
+    assert_output "7"
+}
+
+@test "Recognizes 8" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+|_|
+|_|
+   
+INPUT
+    assert_success
+    assert_output "8"
+}
+
+@test "Recognizes 9" {
+    run gawk -f ocr-numbers.awk << INPUT
+ _ 
+|_|
+ _|
+   
+INPUT
+    assert_success
+    assert_output "9"
+}
+
+@test "Recognizes string of decimal numbers" {
+    run gawk -f ocr-numbers.awk << INPUT
+    _  _     _  _  _  _  _  _ 
+  | _| _||_||_ |_   ||_||_|| |
+  ||_  _|  | _||_|  ||_| _||_|
+                              
+INPUT
+    assert_success
+    assert_output "1234567890"
+}
+
+@test "Numbers separated by empty lines are recognized. Lines are joined by commas." {
+    run gawk -f ocr-numbers.awk << INPUT
+    _  _ 
+  | _| _|
+  ||_  _|
+         
+    _  _ 
+|_||_ |_ 
+  | _||_|
+         
+ _  _  _ 
+  ||_||_|
+  ||_| _|
+         
+INPUT
+    assert_success
+    assert_output "123,456,789"
+}


### PR DESCRIPTION
Introduced a new feature in AWK to recognize optical character recognition (OCR) numbers. The newly added files include an AWK script that attempts to parse 3x4 grid of pipes, underscores, and spaces into corresponding digit, a comprehensive BATS test suite to ensure accuracy of recognition, and an informative README to provide detailed instructions. The implemented AWK script also includes error handling for unrecognizable and incorrect size inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced OCR (Optical Character Recognition) functionality to convert a 3 x 4 grid of pipes, underscores, and spaces into numeric digits or identify garbled input. This includes processing single and multi-character binary strings representing numbers 0-9 and handling multiple numbers on separate lines.
- **Documentation**
	- Added a README explaining the new OCR number conversion functionality.
- **Tests**
	- Implemented a comprehensive test suite to ensure the OCR functionality accurately recognizes digits, handles errors, replaces unreadable characters, and recognizes sequences of decimal numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->