### PR TITLE
Add pangram exercise and test cases

### DIFF
--- a/pangram/README.md
+++ b/pangram/README.md
@@ -1,0 +1,24 @@
+# Pangram
+
+Welcome to Pangram on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Determine if a sentence is a pangram.
+A pangram (Greek: παν γράμμα, pan gramma, "every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is:
+
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of letters `a` to `z`, inclusive, and is case insensitive.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Wikipedia - https://en.wikipedia.org/wiki/Pangram

--- a/pangram/pangram.awk
+++ b/pangram/pangram.awk
@@ -1,0 +1,12 @@
+BEGIN {
+    IGNORECASE = 1
+    Alphabet = "abcdefghijklmnopqrstuvwxyz"
+}
+{
+    print isPangram() ? "true" : "false"
+}
+function isPangram() {
+    # The input sentence forms the character range as regular expression.
+    # We add a space in case if input sentence is an empty string.
+    return !length(gensub("[ "$0"]", "", "g", Alphabet))
+}

--- a/pangram/test-pangram.bats
+++ b/pangram/test-pangram.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# Check if the given string is a pangram
+
+@test "empty sentence" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f pangram.awk <<< ""
+  assert_success
+  assert_output "false"
+}
+
+@test "perfect lower case" {
+  run gawk -f pangram.awk <<< "abcdefghijklmnopqrstuvwxyz"
+  assert_success
+  assert_output "true"
+}
+
+@test "only lower case" {
+  run gawk -f pangram.awk <<< "the quick brown fox jumps over the lazy dog"
+  assert_success
+  assert_output "true"
+}
+
+@test "missing the letter 'x'" {
+  run gawk -f pangram.awk <<< "a quick movement of the enemy will jeopardize five gunboats"
+  assert_success
+  assert_output "false"
+}
+
+@test "missing the letter 'h'" {
+  run gawk -f pangram.awk <<< "five boxing wizards jump quickly at it"
+  assert_success
+  assert_output "false"
+}
+
+@test "with underscores" {
+  run gawk -f pangram.awk <<< "the_quick_brown_fox_jumps_over_the_lazy_dog"
+  assert_success
+  assert_output "true"
+}
+
+@test "with numbers" {
+  run gawk -f pangram.awk <<< "the 1 quick brown fox jumps over the 2 lazy dogs"
+  assert_success
+  assert_output "true"
+}
+
+@test "missing letters replaced by numbers" {
+  run gawk -f pangram.awk <<< "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"
+  assert_success
+  assert_output "false"
+}
+
+@test "mixed case and punctuation" {
+  run gawk -f pangram.awk <<< "\"Five quacking Zephyrs jolt my wax bed.\""
+  assert_success
+  assert_output "true"
+}
+
+@test "a-m and A-M are 26 different characters but not a pangram" {
+  run gawk -f pangram.awk <<< "abcdefghijklm ABCDEFGHIJKLM"
+  assert_success
+  assert_output "false"
+}

--- a/pig-latin/README.md
+++ b/pig-latin/README.md
@@ -1,0 +1,34 @@
+# Pig Latin
+
+Welcome to Pig Latin on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Implement a program that translates from English to Pig Latin.
+
+Pig Latin is a made-up children's language that's intended to be confusing.
+It obeys a few simple rules (below), but when it's spoken quickly it's really difficult for non-children (and non-native speakers) to understand.
+
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to the end of the word.
+  Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").
+- **Rule 2**: If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word.
+  Consonant sounds can be made up of multiple consonants, a.k.a. a consonant cluster (e.g. "chair" -> "airchay").
+- **Rule 3**: If a word starts with a consonant sound followed by "qu", move it to the end of the word, and then add an "ay" sound to the end of the word (e.g. "square" -> "aresquay").
+- **Rule 4**: If a word contains a "y" after a consonant cluster or as the second letter in a two letter word it makes a vowel sound (e.g. "rhythm" -> "ythmrhay", "my" -> "ymay").
+
+There are a few more rules for edge cases, and there are regional variants too.
+
+Read more about [Pig Latin on Wikipedia][pig-latin].
+
+[pig-latin]: https://en.wikipedia.org/wiki/Pig_latin
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+The Pig Latin exercise at Test First Teaching by Ultrasaurus - https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/

--- a/pig-latin/pig-latin.awk
+++ b/pig-latin/pig-latin.awk
@@ -1,0 +1,7 @@
+{for (i = 1; i <= NF; ++i) $i = pigify($i)} 1
+
+function pigify(word,   part) {
+    if (word ~ /^([aouei]|xr|yt)/) return word"ay"
+    match(word, /^([^aouei]?qu|[^aouei][^aoueiy]*)(.*)/, part)
+    return part[2] part[1] "ay"
+}

--- a/pig-latin/test-pig-latin.bats
+++ b/pig-latin/test-pig-latin.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# "ay" is added to words that start with vowels
+
+@test word_beginning_with_a {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f pig-latin.awk <<< "apple"
+    assert_success
+    assert_output "appleay"
+}
+
+@test word_beginning_with_e {
+    run gawk -f pig-latin.awk <<< "ear"
+    assert_success
+    assert_output "earay"
+}
+
+@test word_beginning_with_i {
+    run gawk -f pig-latin.awk <<< "igloo"
+    assert_success
+    assert_output "iglooay"
+}
+
+@test word_beginning_with_o {
+    run gawk -f pig-latin.awk <<< "object"
+    assert_success
+    assert_output "objectay"
+}
+
+@test word_beginning_with_u {
+    run gawk -f pig-latin.awk <<< "under"
+    assert_success
+    assert_output "underay"
+}
+
+@test word_beginning_with_equ {
+    run gawk -f pig-latin.awk <<< "equal"
+    assert_success
+    assert_output "equalay"
+}
+
+# first letter and ay are moved to the end of words that start with consonants
+
+@test word_beginning_with_p {
+    run gawk -f pig-latin.awk <<< "pig"
+    assert_success
+    assert_output "igpay"
+}
+
+@test word_beginning_with_k {
+    run gawk -f pig-latin.awk <<< "koala"
+    assert_success
+    assert_output "oalakay"
+}
+
+@test word_beginning_with_x {
+    run gawk -f pig-latin.awk <<< "xenon"
+    assert_success
+    assert_output "enonxay"
+}
+
+@test word_beginning_with_q_no_u {
+    run gawk -f pig-latin.awk <<< "qat"
+    assert_success
+    assert_output "atqay"
+}
+
+# some letter clusters are treated like a single consonant
+
+@test word_beginning_with_ch {
+    run gawk -f pig-latin.awk <<< "chair"
+    assert_success
+    assert_output "airchay"
+}
+
+@test word_beginning_with_squ {
+    run gawk -f pig-latin.awk <<< "square"
+    assert_success
+    assert_output "aresquay"
+}
+
+@test word_beginning_with_th {
+    run gawk -f pig-latin.awk <<< "therapy"
+    assert_success
+    assert_output "erapythay"
+}
+
+@test word_beginning_with_thr {
+    run gawk -f pig-latin.awk <<< "thrush"
+    assert_success
+    assert_output "ushthray"
+}
+
+@test word_beginning_with_sch {
+    run gawk -f pig-latin.awk <<< "school"
+    assert_success
+    assert_output "oolschay"
+}
+
+# some letter clusters are treated like a single vowel
+
+@test word_beginning_with_yt {
+    run gawk -f pig-latin.awk <<< "yttria"
+    assert_success
+    assert_output "yttriaay"
+}
+
+@test word_beginning_with_xr {
+    run gawk -f pig-latin.awk <<< "xray"
+    assert_success
+    assert_output "xrayay"
+}
+
+# position of y in a word determines if it is a consonant or a vowel
+
+@test word_beginning_with_y {
+    run gawk -f pig-latin.awk <<< "yellow"
+    assert_success
+    assert_output "ellowyay"
+}
+
+@test word_rhythm {
+    run gawk -f pig-latin.awk <<< "rhythm"
+    assert_success
+    assert_output "ythmrhay"
+}
+
+@test word_my {
+    run gawk -f pig-latin.awk <<< "my"
+    assert_success
+    assert_output "ymay"
+}
+
+# phrases are translated
+@test a_whole_phrase {
+    run gawk -f pig-latin.awk <<< "quick fast run"
+    assert_success
+    assert_output "ickquay astfay unray"
+}


### PR DESCRIPTION
The pangram exercise including its description and test cases has been added to the AWK track. These changes also include the functional AWK script to evaluate if a sentence is a pangram or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a pangram checker that determines if a sentence uses every letter of the alphabet at least once.
- **Documentation**
	- Added instructions and examples for understanding and using the pangram checker.
- **Tests**
	- Implemented tests to ensure the pangram checker works accurately across various scenarios, including different cases and presence of numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->