### PR TITLE
Add RNA to protein translation script and tests

### DIFF
--- a/protein-translation/README.md
+++ b/protein-translation/README.md
@@ -1,0 +1,60 @@
+# Protein Translation
+
+Welcome to Protein Translation on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
+If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+Codon                 | Protein
+:---                  | :---
+AUG                   | Methionine
+UUU, UUC              | Phenylalanine
+UUA, UUG              | Leucine
+UCU, UCC, UCA, UCG    | Serine
+UAU, UAC              | Tyrosine
+UGU, UGC              | Cysteine
+UGG                   | Tryptophan
+UAA, UAG, UGA         | STOP
+
+Learn more about [protein translation on Wikipedia][protein-translation].
+
+[protein-translation]: https://en.wikipedia.org/wiki/Translation_(biology)
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+Tyler Long

--- a/protein-translation/protein-translation.awk
+++ b/protein-translation/protein-translation.awk
@@ -1,0 +1,26 @@
+BEGIN {
+    FPAT = "..?.?"
+    Stop = @/UAA|UAG|UGA/
+    Protein["AUG"] = "Methionine"
+    Protein["UUU"] = Protein["UUC"] = "Phenylalanine"
+    Protein["UUA"] = Protein["UUG"] = "Leucine"
+    Protein["UCU"] = Protein["UCC"] = Protein["UCA"] = Protein["UCG"] = "Serine"
+    Protein["UAU"] = Protein["UAC"] = "Tyrosine"
+    Protein["UGU"] = Protein["UGC"] = "Cysteine"
+    Protein["UGG"] = "Tryptophan"
+}
+{
+    for (i = 1; i<= NF; ++i)
+        if ($i ~ Stop)
+            NF = i - 1
+        else
+            $i = translate($i)
+    print
+}
+
+function translate(codon) {
+    if (codon in Protein)
+        return Protein[codon]
+    print "Invalid codon"
+    exit 1
+}

--- a/protein-translation/test-protein-translation.bats
+++ b/protein-translation/test-protein-translation.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# Translate input RNA sequences into proteins
+@test "Empty RNA sequence results in no proteins" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f protein-translation.awk <<< ""
+    assert_success
+    assert_output ""
+}
+
+@test "Methionine RNA sequence" {       
+    run gawk -f protein-translation.awk <<< "AUG"
+    assert_success
+    assert_output "Methionine"
+}
+
+@test "Phenylalanine RNA sequence 1" {  
+    run gawk -f protein-translation.awk <<< "UUU"
+    assert_success
+    assert_output "Phenylalanine"
+}
+
+@test "Phenylalanine RNA sequence 2" {  
+    run gawk -f protein-translation.awk <<< "UUC"
+    assert_success
+    assert_output "Phenylalanine"
+}
+
+@test "Leucine RNA sequence 1" {        
+    run gawk -f protein-translation.awk <<< "UUA"
+    assert_success
+    assert_output "Leucine"
+}
+
+@test "Leucine RNA sequence 2" {        
+    run gawk -f protein-translation.awk <<< "UUG"
+    assert_success
+    assert_output "Leucine"
+}
+
+@test "Serine RNA sequence 1" { 
+    run gawk -f protein-translation.awk <<< "UCU"
+    assert_success
+    assert_output "Serine"
+}
+
+@test "Serine RNA sequence 2" { 
+    run gawk -f protein-translation.awk <<< "UCC"
+    assert_success
+    assert_output "Serine"
+}
+
+@test "Serine RNA sequence 3" { 
+    run gawk -f protein-translation.awk <<< "UCA"
+    assert_success
+    assert_output "Serine"
+}
+
+@test "Serine RNA sequence 4" { 
+    run gawk -f protein-translation.awk <<< "UCG"
+    assert_success
+    assert_output "Serine"
+}
+
+@test "Tyrosine RNA sequence 1" {       
+    run gawk -f protein-translation.awk <<< "UAU"
+    assert_success
+    assert_output "Tyrosine"
+}
+
+@test "Tyrosine RNA sequence 2" {       
+    run gawk -f protein-translation.awk <<< "UAC"
+    assert_success
+    assert_output "Tyrosine"
+}
+
+@test "Cysteine RNA sequence 1" {       
+    run gawk -f protein-translation.awk <<< "UGU"
+    assert_success
+    assert_output "Cysteine"
+}
+
+@test "Cysteine RNA sequence 2" {       
+    run gawk -f protein-translation.awk <<< "UGC"
+    assert_success
+    assert_output "Cysteine"
+}
+
+@test "Tryptophan RNA sequence" {       
+    run gawk -f protein-translation.awk <<< "UGG"
+    assert_success
+    assert_output "Tryptophan"
+}
+
+@test "STOP codon RNA sequence 1" {     
+    run gawk -f protein-translation.awk <<< "UAA"
+    assert_success
+    assert_output ""
+}
+
+@test "STOP codon RNA sequence 2" {     
+    run gawk -f protein-translation.awk <<< "UAG"
+    assert_success
+    assert_output ""
+}
+
+@test "STOP codon RNA sequence 3" {     
+    run gawk -f protein-translation.awk <<< "UGA"
+    assert_success
+    assert_output ""
+}
+
+@test "Sequence of two protein codons translates into proteins" {
+    run gawk -f protein-translation.awk <<< "UUUUUU"
+    assert_success
+    assert_output "Phenylalanine Phenylalanine"
+}
+
+@test "Sequence of two different protein codons translates into proteins" {
+    run gawk -f protein-translation.awk <<< "UUAUUG"
+    assert_success
+    assert_output "Leucine Leucine"
+}
+
+@test "Translate RNA strand into correct protein list" {        
+    run gawk -f protein-translation.awk <<< "AUGUUUUGG"
+    assert_success
+    assert_output "Methionine Phenylalanine Tryptophan"
+}
+
+@test "Translation stops if STOP codon at beginning of sequence" {      
+    run gawk -f protein-translation.awk <<< "UAGUGG"
+    assert_success
+    assert_output ""
+}
+
+@test "Translation stops if STOP codon at end of two-codon sequence" {  
+    run gawk -f protein-translation.awk <<< "UGGUAG"
+    assert_success
+    assert_output "Tryptophan"
+}
+
+@test "Translation stops if STOP codon at end of three-codon sequence" {        
+    run gawk -f protein-translation.awk <<< "AUGUUUUAA"
+    assert_success
+    assert_output "Methionine Phenylalanine"
+}
+
+@test "Translation stops if STOP codon in middle of three-codon sequence" {     
+    run gawk -f protein-translation.awk <<< "UGGUAGUGG"
+    assert_success
+    assert_output "Tryptophan"
+}
+
+@test "Translation stops if STOP codon in middle of six-codon sequence" {       
+    run gawk -f protein-translation.awk <<< "UGGUGUUAUUAAUGGUUU"
+    assert_success
+    assert_output "Tryptophan Cysteine Tyrosine"
+}
+
+@test "Error case" {
+    run gawk -f protein-translation.awk <<< "UGG---AUG"
+    assert_failure
+    assert_output "Invalid codon"
+}
+
+@test "Non-existing codon can't translate" {
+    run gawk -f protein-translation.awk <<< "AAA"
+    assert_failure
+    assert_output "Invalid codon"
+}
+
+@test "Unknown amino acids, not part of a codon, can't translate" {
+    run gawk -f protein-translation.awk <<< "XYZ"
+    assert_failure
+    assert_output "Invalid codon"
+}
+
+@test "Incomplete RNA sequence can't translate" {
+    run gawk -f protein-translation.awk <<< "AUGU"
+    assert_failure
+    assert_output "Invalid codon"
+}
+
+@test "Incomplete RNA sequence can translate if valid until a STOP codon" {
+    run gawk -f protein-translation.awk <<< "UUCUUCUAAUGGU"
+    assert_success
+    assert_output "Phenylalanine Phenylalanine"
+}

--- a/queen-attack/README.md
+++ b/queen-attack/README.md
@@ -1,0 +1,40 @@
+# Queen Attack
+
+Welcome to Queen Attack on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.
+
+In the game of chess, a queen can attack pieces which are on the same row, column, or diagonal.
+
+A chessboard can be represented by an 8 by 8 array.
+
+So if you are told the white queen is at `c5` (zero-indexed at column 2, row 3) and the black queen at `f2` (zero-indexed at column 5, row 6), then you know that the set-up is like so:
+
+```text
+  a b c d e f g h
+8 _ _ _ _ _ _ _ _ 8
+7 _ _ _ _ _ _ _ _ 7
+6 _ _ _ _ _ _ _ _ 6
+5 _ _ W _ _ _ _ _ 5
+4 _ _ _ _ _ _ _ _ 4
+3 _ _ _ _ _ _ _ _ 3
+2 _ _ _ _ _ B _ _ 2
+1 _ _ _ _ _ _ _ _ 1
+  a b c d e f g h
+```
+
+You are also be able to answer whether the queens can attack each other.
+In this case, that answer would be yes, they can, because both pieces share a diagonal.
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+J Dalbey's Programming Practice problems - https://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html

--- a/queen-attack/queen-attack.awk
+++ b/queen-attack/queen-attack.awk
@@ -1,0 +1,16 @@
+isValid() {
+    print canAttack() ? "true" : "false"; next
+}
+{
+    print "invalid"; exit 1
+}
+
+function isValid() {
+    return /^([0-7] ){3}[0-7]/ && ($1 != $3 || $2 != $4)
+}
+function canAttack() {
+    return $1 == $3 || $2 == $4 || abs($1 - $3) == abs($2 - $4)
+}
+function abs(v) {
+    return v < 0 ? -v : v
+}

--- a/queen-attack/test-queen-attack.bats
+++ b/queen-attack/test-queen-attack.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# Test creation of Queens with invalid positions
+
+# Program input: one line with 4 integers, which represents the (x, y) position of two queens.
+# i.e. white_x white_y black_x black_y
+
+@test "queen must have positive row" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    # White queen at (-2, 2) and black queen at (7, 7).
+    run gawk -f queen-attack.awk <<< "-2 2 7 7"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+@test "queen must have row on board" {
+    run gawk -f queen-attack.awk <<< "8 4 7 7"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+@test "queen must have positive column" {
+    run gawk -f queen-attack.awk <<< "2 -2 7 7"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+@test "queen must have column on board" {
+    run gawk -f queen-attack.awk <<< "4 8 7 7"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+@test "same position" {
+    run gawk -f queen-attack.awk <<< "7 7 7 7"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+
+# Test the ability of one queen to attack another
+
+@test "can not attack" {
+    run gawk -f queen-attack.awk <<< "2 4 6 6"
+    assert_success 
+    assert_output "false"
+}
+
+@test "can attack on same row" {
+    run gawk -f queen-attack.awk <<< "2 4 2 6"
+    assert_success 
+    assert_output "true"
+}
+
+@test "can attack on same column" {
+    run gawk -f queen-attack.awk <<< "4 5 2 5"
+    assert_success 
+    assert_output "true"
+}
+
+@test "can attack on first diagonal" {
+    run gawk -f queen-attack.awk <<< "2 2 0 4"
+    assert_success 
+    assert_output "true"
+}
+
+@test "can attack on second diagonal" {
+    run gawk -f queen-attack.awk <<< "2 2 3 1"
+    assert_success 
+    assert_output "true"
+}
+
+@test "can attack on third diagonal" {
+    run gawk -f queen-attack.awk <<< "2 2 1 1"
+    assert_success 
+    assert_output "true"
+}
+
+@test "can attack on fourth diagonal" {
+    run gawk -f queen-attack.awk <<< "1 7 0 6"
+    assert_success 
+    assert_output "true"
+}
+
+@test "cannot attack if falling diagonals are only the same when reflected across the longest falling diagonal" {
+    run gawk -f queen-attack.awk <<< "4 1 2 5"
+    assert_success 
+    assert_output "false"
+}


### PR DESCRIPTION
This commit introduces an AWK script that translates sequences of RNA into proteins. Associated tests have also been added to ensure the program works as expected. It handles regular codons, 'STOP' codons, and errors, such as invalid or incomplete sequences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a guide for translating RNA sequences into proteins.
    - Added functionality for translating RNA codons into proteins.
    - Implemented tests for the RNA to protein translation process, including handling of special cases.
    - Introduced the "Queen Attack" game on Exercism's AWK Track with functions to check if queens can attack each other on a chessboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->