### PR TITLE
Implement raindrops exercise in AWK with tests

### DIFF
--- a/raindrops/README.md
+++ b/raindrops/README.md
@@ -1,0 +1,40 @@
+# Raindrops
+
+Welcome to Raindrops on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors.
+A factor is a number that evenly divides into another number, leaving no remainder.
+The simplest way to test if one number is a factor of another is to use the [modulo operation][modulo].
+
+The rules of `raindrops` are that if a given number:
+
+- has 3 as a factor, add 'Pling' to the result.
+- has 5 as a factor, add 'Plang' to the result.
+- has 7 as a factor, add 'Plong' to the result.
+- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of the number.
+
+## Examples
+
+- 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
+- 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
+- 34 is not factored by 3, 5, or 7, so the result would be "34".
+
+[modulo]: https://en.wikipedia.org/wiki/Modulo_operation
+
+## Your awk program
+
+The tests invoke your program with `gawk`, passing a value into an awk variable, but providing **no filenames or redirected input**.
+You'll need to implement the logic inside the `BEGIN` block.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division. - https://en.wikipedia.org/wiki/Fizz_buzz

--- a/raindrops/raindrops.awk
+++ b/raindrops/raindrops.awk
@@ -1,0 +1,19 @@
+# These variables are initialized on the command line (using '-v'):
+# - num
+
+BEGIN {
+    if (num % 3 == 0) {
+        result = "Pling"
+    }
+    if (num % 5 == 0) {
+        result = result "Plang"
+    }
+    if (num % 7 == 0) {
+        result = result "Plong"
+    }
+    if (! result) {
+        result = num
+    }
+
+    print result
+}

--- a/raindrops/test-raindrops.bats
+++ b/raindrops/test-raindrops.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "the sound for 1 is 1" {
+  run gawk -v num=1 -f raindrops.awk
+  assert_success
+  assert_output "1"
+}
+
+@test "the sound for 3 is Pling" {
+  run gawk -v num=3 -f raindrops.awk
+  assert_success
+  assert_output "Pling"
+}
+
+@test "the sound for 5 is Plang" {
+  run gawk -v num=5 -f raindrops.awk
+  assert_success
+  assert_output "Plang"
+}
+
+@test "the sound for 7 is Plong" {
+  run gawk -v num=7 -f raindrops.awk
+  assert_success
+  assert_output "Plong"
+}
+
+@test "the sound for 6 is Pling as it has a factor 3" {
+  run gawk -v num=6 -f raindrops.awk
+  assert_success
+  assert_output "Pling"
+}
+
+@test "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base" {
+  run gawk -v num=8 -f raindrops.awk
+  assert_success
+  assert_output "8"
+}
+
+@test "the sound for 9 is Pling as it has a factor 3" {
+  run gawk -v num=9 -f raindrops.awk
+  assert_success
+  assert_output "Pling"
+}
+
+@test "the sound for 10 is Plang as it has a factor 5" {
+  run gawk -v num=10 -f raindrops.awk
+  assert_success
+  assert_output "Plang"
+}
+
+@test "the sound for 14 is Plong as it has a factor of 7" {
+  run gawk -v num=14 -f raindrops.awk
+  assert_success
+  assert_output "Plong"
+}
+
+@test "the sound for 15 is PlingPlang as it has factors 3 and 5" {
+  run gawk -v num=15 -f raindrops.awk
+  assert_success
+  assert_output "PlingPlang"
+}
+
+@test "the sound for 21 is PlingPlong as it has factors 3 and 7" {
+  run gawk -v num=21 -f raindrops.awk
+  assert_success
+  assert_output "PlingPlong"
+}
+
+@test "the sound for 25 is Plang as it has a factor 5" {
+  run gawk -v num=25 -f raindrops.awk
+  assert_success
+  assert_output "Plang"
+}
+
+@test "the sound for 27 is Pling as it has a factor 3" {
+  run gawk -v num=27 -f raindrops.awk
+  assert_success
+  assert_output "Pling"
+}
+
+@test "the sound for 35 is PlangPlong as it has factors 5 and 7" {
+  run gawk -v num=35 -f raindrops.awk
+  assert_success
+  assert_output "PlangPlong"
+}
+
+@test "the sound for 49 is Plong as it has a factor 7" {
+  run gawk -v num=49 -f raindrops.awk
+  assert_success
+  assert_output "Plong"
+}
+
+@test "the sound for 52 is 52" {
+  run gawk -v num=52 -f raindrops.awk
+  assert_success
+  assert_output "52"
+}
+
+@test "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7" {
+  run gawk -v num=105 -f raindrops.awk
+  assert_success
+  assert_output "PlingPlangPlong"
+}
+
+@test "the sound for 3125 is Plang as it has a factor 5" {
+  run gawk -v num=3125 -f raindrops.awk
+  assert_success
+  assert_output "Plang"
+}


### PR DESCRIPTION
This commit adds the raindrops exercise to the AWK track on Exercism. The provided AWK script utilizes the modulo operation to determine factors of a number and output corresponding "raindrop" sounds, while the comprehensive suite of bats tests ensures correct functionality for a variety of input values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `Raindrops` program, converting numbers into strings based on their factors of 3, 5, and 7, corresponding to 'Pling', 'Plang', and 'Plong', or the number itself otherwise.
- **Documentation**
	- Added a comprehensive guide in the `README.md` file for the `Raindrops` program.
- **Tests**
	- Implemented test cases to ensure the `Raindrops` program accurately converts numbers into the correct sounds based on their factors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->