### PR TITLE
Add rectangles exercise and its solution in AWK

### DIFF
--- a/rectangles/README.md
+++ b/rectangles/README.md
@@ -1,0 +1,74 @@
+# Rectangles
+
+Welcome to Rectangles on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Count the rectangles in an ASCII diagram like the one below.
+
+```text
+   +--+
+  ++  |
++-++--+
+|  |  |
++--+--+
+```
+
+The above diagram contains these 6 rectangles:
+
+```text
+
+
++-----+
+|     |
++-----+
+```
+
+```text
+   +--+
+   |  |
+   |  |
+   |  |
+   +--+
+```
+
+```text
+   +--+
+   |  |
+   +--+
+
+
+```
+
+```text
+
+
+   +--+
+   |  |
+   +--+
+```
+
+```text
+
+
++--+
+|  |
++--+
+```
+
+```text
+
+  ++
+  ++
+
+
+```
+
+You may assume that the input is always a proper rectangle (i.e. the length of every line equals the length of the first line).
+
+## Source
+
+### Created by
+
+- @glennj

--- a/rectangles/rectangles.awk
+++ b/rectangles/rectangles.awk
@@ -1,0 +1,58 @@
+BEGIN {
+    FS = ""
+}
+{
+    for (i = 1; i <= NF; ++i) {
+        bit = lshift(1, i - 1)
+        if ($i ~ /[-+]/) H[NR] = or(H[NR], bit)
+        if ($i ~ /[|+]/) V[NR] = or(V[NR], bit)
+    }
+}
+END {
+    Height = NR
+    Width = NF
+
+    for (rowA = 1; rowA < Height; ++rowA) {
+        for (colA = 1; colA < Width; ++colA) {
+            total += cornerA(rowA, colA)
+        }
+    }
+    print +total
+}
+
+function isPlus(row, col) {
+    return and(H[row], V[row], lshift(1, col - 1))
+}
+
+function isVerticalLine(row, col) {
+    return row <= Height && and(V[row], lshift(1, col - 1))
+}
+
+function isHorizontalLine(row, col) {
+    return col <= Width && and(H[row], lshift(1, col - 1))
+}
+
+function cornerA(rowA, colA,   total,colB) {
+    if (!isPlus(rowA, colA)) return 0
+    for (colB = colA + 1; isHorizontalLine(rowA, colB); ++colB) {
+        total += cornerB(rowA, colA, colB)
+    }
+    return +total
+}
+
+function cornerB(rowA, colA, colB,   rowC,total) {
+    if (!isPlus(rowA, colB)) return 0
+    for (rowC = rowA + 1; isVerticalLine(rowC, colA) && isVerticalLine(rowC, colB); ++rowC) {
+        total += cornerC(colA, colB, rowC)
+    }
+    return +total
+}
+
+function cornerC(colA, colB, rowC,   i) {
+    if (!isPlus(rowC, colB)) return 0
+    if (!isPlus(rowC, colA)) return 0
+    for (i = colB - 1; i > colA; --i) {
+        if (!isHorizontalLine(rowC, i)) return 0
+    }
+    return 1
+}

--- a/rectangles/rectangles_old.awk
+++ b/rectangles/rectangles_old.awk
@@ -1,0 +1,62 @@
+BEGIN {
+    VerticalLine = @/[|+]/
+    HorizontalLine = @/[-+]/
+    delete Board
+}
+{
+    Board[NR] = $0
+}
+END {
+    Height = length(Board)
+
+    for (row in Board) {
+        Width = length(Board[row])
+        for (i = 1; i < Width; ++i) {
+            total += cornerA(row, i)
+        }
+    }
+    print +total
+}
+
+function cornerA(rowA, colA,   total,colB) {
+    if (!isCross(rowA, colA)) return 0
+    for (colB = colA + 1; isHorizontalLine(rowA, colB); ++colB) {
+        total += cornerB(rowA, colA, colB)
+    }
+    return +total
+}
+
+function cornerB(rowA, colA, colB,   rowC,total) {
+    if (!isCross(rowA, colB)) return 0
+    for (rowC = rowA + 1; isVerticalLine(rowC, colB); ++rowC) {
+        total += cornerC(rowA, colA, colB, rowC)
+    }
+    return +total
+}
+
+function cornerC(rowA, colA, colB, rowC,   i) {
+    if (!isCross(rowC, colA)) return 0
+    for (i = colB - 1; i > colA; --i) {
+        if (!isHorizontalLine(rowC, i)) return 0
+    }
+    for (i = rowC - 1; i > rowA; --i) {
+        if (!isVerticalLine(i, colA)) return 0
+    }
+    return 1
+}
+
+function symbol(row, col) {
+    return substr(Board[row], col, 1)
+}
+
+function isCross(row, col) {
+    return symbol(row, col) == "+"
+}
+
+function isVerticalLine(row, col) {
+    return row <= Height && symbol(row, col) ~ VerticalLine
+}
+
+function isHorizontalLine(row, col) {
+    return col <= Width && symbol(row, col) ~ HorizontalLine
+}

--- a/rectangles/test-rectangles.bats
+++ b/rectangles/test-rectangles.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "no rows" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f rectangles.awk < /dev/null
+    assert_success
+    assert_output "0"
+}
+
+@test "no columns" {
+    run gawk -f rectangles.awk <<< ""
+    assert_success
+    assert_output "0"
+}
+
+@test "no rectangles" {
+    run gawk -f rectangles.awk <<< " "
+    assert_success
+    assert_output "0"
+}
+
+@test "one rectangle" {
+    run gawk -f rectangles.awk <<INPUT
++-+
+| |
++-+
+INPUT
+    assert_success
+    assert_output "1"
+}
+
+@test "two rectangles without shared parts" {
+    run gawk -f rectangles.awk <<INPUT
+  +-+
+  | |
++-+-+
+| |  
++-+  
+INPUT
+    assert_success
+    assert_output "2"
+}
+
+@test "five rectangles with shared parts" {
+    run gawk -f rectangles.awk <<INPUT
+  +-+
+  | |
++-+-+
+| | |
++-+-+
+INPUT
+    assert_success
+    assert_output "5"
+}
+
+@test "rectangle of height 1 is counted" {
+    run gawk -f rectangles.awk <<INPUT
++--+
++--+
+INPUT
+    assert_success
+    assert_output "1"
+}
+
+@test "rectangle of width 1 is counted" {
+    run gawk -f rectangles.awk <<INPUT
+++
+||
+++
+INPUT
+    assert_success
+    assert_output "1"
+}
+
+@test "1x1 square is counted" {
+    run gawk -f rectangles.awk <<INPUT
+++
+++
+INPUT
+    assert_success
+    assert_output "1"
+}
+
+@test "only complete rectangles are counted" {
+    run gawk -f rectangles.awk <<INPUT
+  +-+
+    |
++-+-+
+| | -
++-+-+
+INPUT
+    assert_success
+    assert_output "1"
+}
+
+@test "rectangles can be of different sizes" {
+    run gawk -f rectangles.awk <<INPUT
++------+----+
+|      |    |
++---+--+    |
+|   |       |
++---+-------+
+INPUT
+    assert_success
+    assert_output "3"
+}
+
+@test "corner is required for a rectangle to be complete" {
+    run gawk -f rectangles.awk <<INPUT
++------+----+
+|      |    |
++------+    |
+|   |       |
++---+-------+
+INPUT
+    assert_success
+    assert_output "2"
+}
+
+@test "large input with many rectangles" {
+    run gawk -f rectangles.awk <<INPUT
++---+--+----+
+|   +--+----+
++---+--+    |
+|   +--+----+
++---+--+--+-+
++---+--+--+-+
++------+  | |
+          +-+
+INPUT
+    assert_success
+    assert_output "60"
+}
+
+@test "nested rectangles" {
+    run gawk -f rectangles.awk <<INPUT
++-----------+
+|           |
+|      +-+  |
+|      +-+  |
++-----------+
+INPUT
+    assert_success
+    assert_output "2"
+}
+
+@test "side by side rectangles" {
+    run gawk -f rectangles.awk <<INPUT
++------+ +--+
+|      | |  |
++------+ |  |
+         |  |
+         +--+
+INPUT
+    assert_success
+    assert_output "2"
+}
+
+@test "rectangles must have four sides" {
+    run gawk -f rectangles.awk <<INPUT
++-+ +-+
+| | | |
++-+-+-+
+  | |  
++-+-+-+
+| | | |
++-+ +-+
+INPUT
+    assert_success
+    assert_output "5"
+}

--- a/resistor-color-duo/README.md
+++ b/resistor-color-duo/README.md
@@ -1,0 +1,48 @@
+# Resistor Color Duo
+
+Welcome to Resistor Color Duo on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+The program will take color names as input and output a two digit number, even if the input is more than two colors!
+
+The band colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+From the example above:
+brown-green should return 15
+brown-green-violet should return 15 too, ignoring the third color.
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+Maud de Vries, Erik Schierboom - https://github.com/exercism/problem-specifications/issues/1464

--- a/resistor-color-duo/resistor-color-duo.awk
+++ b/resistor-color-duo/resistor-color-duo.awk
@@ -1,0 +1,18 @@
+BEGIN {
+    Colors["black"] = 0
+    Colors["brown"] = 1
+    Colors["red"] = 2
+    Colors["orange"] = 3
+    Colors["yellow"] = 4
+    Colors["green"] = 5
+    Colors["blue"] = 6
+    Colors["violet"] = 7
+    Colors["grey"] = 8
+    Colors["white"] = 9
+}
+$1 in Colors && $2 in Colors {
+    print +(Colors[$1] Colors[$2]); next
+}
+{
+    print "invalid color"; exit 1
+}

--- a/resistor-color-duo/test-resistor-color-duo.bats
+++ b/resistor-color-duo/test-resistor-color-duo.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "brown black" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f resistor-color-duo.awk <<< "brown black"
+    assert_success
+    assert_output "10"
+}
+
+@test "blue grey" {
+    run gawk -f resistor-color-duo.awk <<< "blue grey"
+    assert_success
+    assert_output "68"
+}
+
+@test "yellow violet" {
+    run gawk -f resistor-color-duo.awk <<< "yellow violet"
+    assert_success
+    assert_output "47"
+}
+
+@test "white red" {
+    run gawk -f resistor-color-duo.awk <<< "white red"
+    assert_success
+    assert_output "92"
+}
+
+@test "orange orange" {
+    run gawk -f resistor-color-duo.awk <<< "orange orange"
+    assert_success
+    assert_output "33"
+}
+
+@test "invalid color" {
+    run gawk -f resistor-color-duo.awk <<< "foo"
+    assert_failure
+    assert_output --partial "invalid color"
+}
+
+@test "ignore too many colors" {
+    run gawk -f resistor-color-duo.awk <<< "green brown orange"
+    assert_success
+    assert_output "51"
+}
+
+@test "black brown" {
+    run gawk -f resistor-color-duo.awk <<< "black brown"
+    assert_success
+    assert_output "1"
+}
+
+@test "black grey" {
+    run gawk -f resistor-color-duo.awk <<< "black grey"
+    assert_success
+    assert_output "8"
+}


### PR DESCRIPTION
This commit introduces a new exercise called 'rectangles' to the AWK track. The exercise requires parsing an ASCII diagram to count the number of rectangles. The solution presented uses bitwise operations to identify each corner of a rectangle, and the included tests validate the functionality with various input types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a guide for counting rectangles in ASCII diagrams.
	- Added a script to analyze grids and determine the number of rectangles based on corner configurations.
	- Implemented a test suite for validating the rectangle counting functionality.

- **Documentation**
	- Provided examples and instructions for counting rectangles in the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->