### PR TITLE
Add Resistor Color Trio exercise and AWK solution

### DIFF
--- a/resistor-color-trio/README.md
+++ b/resistor-color-trio/README.md
@@ -1,0 +1,69 @@
+# Resistor Color Trio
+
+Welcome to Resistor Color Trio on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know only three things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+- Each band acts as a digit of a number.
+  For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands.
+  The program will take 3 colors as input, and outputs the correct value, in ohms.
+  The color bands are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+In `resistor-color duo` you decoded the first two colors.
+For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value.
+The main value plus the zeros gives us a value in ohms.
+For the exercise it doesn't matter what ohms really are.
+For example:
+
+- orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
+- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
+
+(If Math is your thing, you may want to think of the zeros as exponents of 10.
+If Math is not your thing, go with the zeros.
+It really is the same thing, just in plain English instead of Math lingo.)
+
+This exercise is about translating the colors into a label:
+
+> "... ohms"
+
+So an input of `"orange", "orange", "black"` should return:
+
+> "33 ohms"
+
+When we get more than a thousand ohms, we say "kiloohms".
+That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+
+So an input of `"orange", "orange", "orange"` should return:
+
+> "33 kiloohms"
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+Maud de Vries, Erik Schierboom - https://github.com/exercism/problem-specifications/issues/1549

--- a/resistor-color-trio/resistor-color-trio.awk
+++ b/resistor-color-trio/resistor-color-trio.awk
@@ -1,0 +1,33 @@
+BEGIN {
+    Colors["black"] = 0
+    Colors["brown"] = 1
+    Colors["red"] = 2
+    Colors["orange"] = 3
+    Colors["yellow"] = 4
+    Colors["green"] = 5
+    Colors["blue"] = 6
+    Colors["violet"] = 7
+    Colors["grey"] = 8
+    Colors["white"] = 9
+
+    Suffix["000000000"] = "giga"
+    Suffix["000000"] = "mega"
+    Suffix["000"] = "kilo"
+
+}
+$1 in Colors && $2 in Colors && $3 in Colors {
+    resistance = +(Colors[$1] Colors[$2]) * 10 ^ Colors[$3]
+
+    for (zeros in Suffix)
+        if (resistance ~ zeros) {
+            resistance /= 10 ^ length(zeros)
+            suffix = Suffix[zeros]
+        }
+
+    print resistance, suffix"ohms"
+    next
+}
+{
+    print "invalid color"
+    exit 1
+}

--- a/resistor-color-trio/test-resistor-color-trio.bats
+++ b/resistor-color-trio/test-resistor-color-trio.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "Orange and orange and black" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f resistor-color-trio.awk <<< "orange orange black"
+    assert_success
+    assert_output "33 ohms"
+}
+
+@test "Blue and grey and brown" {
+    run gawk -f resistor-color-trio.awk <<< "blue grey brown"
+    assert_success
+    assert_output "680 ohms"
+}
+
+@test "Brown and red and red" {
+    run gawk -f resistor-color-trio.awk <<< "brown red red"
+    assert_success
+    assert_output "1200 ohms"
+}
+
+@test "Red and black and red" {
+    run gawk -f resistor-color-trio.awk <<< "red black red"
+    assert_success
+    assert_output "2 kiloohms"
+}
+
+@test "Green and brown and orange" {
+    run gawk -f resistor-color-trio.awk <<< "green brown orange"
+    assert_success
+    assert_output "51 kiloohms"
+}
+
+@test "Yellow and violet and yellow" {
+    run gawk -f resistor-color-trio.awk <<< "yellow violet yellow"
+    assert_success
+    assert_output "470 kiloohms"
+}
+
+@test "Blue and violet and grey" {
+    run gawk -f resistor-color-trio.awk <<< "blue violet grey"
+    assert_success
+    assert_output "6700 megaohms"
+}
+
+@test "Minimum possible value" {
+    run gawk -f resistor-color-trio.awk <<< "black black black"
+    assert_success
+    assert_output "0 ohms"
+}
+
+@test "Maximum possible value" {
+    run gawk -f resistor-color-trio.awk <<< "white white white"
+    assert_success
+    assert_output "99 gigaohms"
+}
+
+
+@test "Invalid first color" {
+    run gawk -f resistor-color-trio.awk <<< "foo white white"
+    assert_failure
+    assert_output    # there is _some_ output
+}
+
+@test "Invalid second color" {
+    run gawk -f resistor-color-trio.awk <<< "white bar white"
+    assert_failure
+    assert_output    # there is _some_ output
+}
+
+@test "Invalid third color" {
+    run gawk -f resistor-color-trio.awk <<< "white white baz"
+    assert_failure
+    assert_output    # there is _some_ output
+}
+
+@test "First two colors make an invalid octal number" {
+    run gawk -f resistor-color-trio.awk <<< "black grey black"
+    assert_success
+    assert_output "8 ohms"
+}
+
+@test "Ignore extra colors" {
+    run gawk -f resistor-color-trio.awk <<< "blue green yellow orange"
+    assert_success
+    assert_output "650 kiloohms"
+}


### PR DESCRIPTION
This commit adds an exercise requiring the translation of three color inputs into resistance values for resistors. The AWK solution provided decodes the band color system to calculate the resistor value in an appropriate scale (ohm, kiloohm, etc) based on input colors. Associated tests ensure the correct resistance is returned for various color combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a program to decode resistor color bands into resistance values in ohms or kiloohms, enhancing the AWK Track on Exercism.
- **Tests**
	- Added test cases to ensure accurate calculation of resistance values based on resistor color codes, covering various combinations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->