### PR TITLE
Add Roman Numerals converter and tests

### DIFF
--- a/roman-numerals/README.md
+++ b/roman-numerals/README.md
@@ -1,0 +1,56 @@
+# Roman Numerals
+
+Welcome to Roman Numerals on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch.
+They conquered most of Europe and ruled it for hundreds of years.
+They invented concrete and straight roads and even bikinis.
+One thing they never discovered though was the number zero.
+This made writing and dating extensive histories of their exploits slightly more challenging, but the system of numbers they came up with is still in use today.
+For example the BBC uses Roman numerals to date their programs.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M.
+(notice these letters have lots of straight lines and are hence easy to hack into stone tablets).
+
+```text
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+The maximum number supported by this notation is 3,999.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+Learn more about [Roman numberals on Wikipedia][roman-numerals].
+
+[roman-numerals]: https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+The Roman Numeral Kata - https://codingdojo.org/kata/RomanNumerals/

--- a/roman-numerals/roman-numerals.awk
+++ b/roman-numerals/roman-numerals.awk
@@ -1,0 +1,19 @@
+BEGIN {
+    PROCINFO["sorted_in"] = "@ind_num_asc"
+
+    NumeralCount = split("M CM D CD C XC L XL X IX V IV I", RomanNumerals)
+    split("1000 900 500 400 100 90 50 40 10 9 5 4 1", ArabicNumerals)
+}
+{
+    print toRomanNumeral($0)
+}
+
+function toRomanNumeral(number, i, roman) {
+    for (i = 1; i <= NumeralCount; ++i) {
+        while (ArabicNumerals[i] <= number) {
+            number -= ArabicNumerals[i]
+            roman = roman RomanNumerals[i]
+        }
+    }
+    return roman
+}

--- a/roman-numerals/test-roman-numerals.bats
+++ b/roman-numerals/test-roman-numerals.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "1 is a single I" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f roman-numerals.awk <<< 1
+    assert_success
+    assert_output "I"
+}
+
+@test "2 is two I's" {
+    run gawk -f roman-numerals.awk <<< 2
+    assert_success
+    assert_output "II"
+}
+
+@test "3 is three I's" {
+    run gawk -f roman-numerals.awk <<< 3
+    assert_success
+    assert_output "III"
+}
+
+@test "4, being 5 - 1, is IV" {
+    run gawk -f roman-numerals.awk <<< 4
+    assert_success
+    assert_output "IV"
+}
+
+@test "5 is a single V" {
+    run gawk -f roman-numerals.awk <<< 5
+    assert_success
+    assert_output "V"
+}
+
+@test "6, being 5 + 1, is VI" {
+    run gawk -f roman-numerals.awk <<< 6
+    assert_success
+    assert_output "VI"
+}
+
+@test "9, being 10 - 1, is IX" {
+    run gawk -f roman-numerals.awk <<< 9
+    assert_success
+    assert_output "IX"
+}
+
+@test "20 is two X's" {
+    run gawk -f roman-numerals.awk <<< 27
+    assert_success
+    assert_output "XXVII"
+}
+
+@test "48 is not 50 - 2 but rather 40 + 8" {
+    run gawk -f roman-numerals.awk <<< 48
+    assert_success
+    assert_output "XLVIII"
+}
+
+@test "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1" {
+    run gawk -f roman-numerals.awk <<< 49
+    assert_success
+    assert_output "XLIX"
+}
+
+@test "50 is a single L" {
+    run gawk -f roman-numerals.awk <<< 59
+    assert_success
+    assert_output "LIX"
+}
+
+@test "90, being 100 - 10, is XC" {
+    run gawk -f roman-numerals.awk <<< 93
+    assert_success
+    assert_output "XCIII"
+}
+
+@test "100 is a single C" {
+    run gawk -f roman-numerals.awk <<< 141
+    assert_success
+    assert_output "CXLI"
+}
+
+@test "60, being 50 + 10, is LX" {
+    run gawk -f roman-numerals.awk <<< 163
+    assert_success
+    assert_output "CLXIII"
+}
+
+@test "400, being 500 - 100, is CD" {
+    run gawk -f roman-numerals.awk <<< 402
+    assert_success
+    assert_output "CDII"
+}
+
+@test "500 is a single D" {
+    run gawk -f roman-numerals.awk <<< 575
+    assert_success
+    assert_output "DLXXV"
+}
+
+@test "900, being 1000 - 100, is CM" {
+    run gawk -f roman-numerals.awk <<< 911
+    assert_success
+    assert_output "CMXI"
+}
+
+@test "1000 is a single M" {
+    run gawk -f roman-numerals.awk <<< 1024
+    assert_success
+    assert_output "MXXIV"
+}
+
+@test "3000 is three M's" {
+    run gawk -f roman-numerals.awk <<< 3000
+    assert_success
+    assert_output "MMM"
+}
+
+@test "3001 is three MMMI" {
+    run gawk -f roman-numerals.awk <<< 3001
+    assert_success
+    assert_output "MMMI"
+}
+
+@test "3999 is three MMMCMXCIX" {
+    run gawk -f roman-numerals.awk <<< 3999
+    assert_success
+    assert_output "MMMCMXCIX"
+}
+
+
+# testing numbers with all roman numerals below a threshold
+
+@test "16 is XVI" {
+    run gawk -f roman-numerals.awk <<< 16
+    assert_success
+    assert_output "XVI"
+}
+
+@test "66 is LXVI" {
+    run gawk -f roman-numerals.awk <<< 66
+    assert_success
+    assert_output "LXVI"
+}
+
+@test "166 is CLXVI" {
+    run gawk -f roman-numerals.awk <<< 166
+    assert_success
+    assert_output "CLXVI"
+}
+
+@test "666 is DCLXVI" {
+    run gawk -f roman-numerals.awk <<< 666
+    assert_success
+    assert_output "DCLXVI"
+}
+
+@test "1666 is MDCLXVI" {
+    run gawk -f roman-numerals.awk <<< 1666
+    assert_success
+    assert_output "MDCLXVI"
+}


### PR DESCRIPTION
Added AWK program to convert Arabic numerals to Roman numerals, along with appropriate tests. The AWK script uses arrays to map Roman numerals to their Arabic equivalents, with a function that continually subtracts the highest possible value to generate the Roman numeral equivalent. The accompanying tests validate the program with a wide range of values. A README.md has also been created to provide instructions.