### PR TITLE
Add Series exercise and tests in AWK

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/coderabbit-overrides.v2.json
+language: "en-US"
+early_access: true
+reviews:
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+  path_filters:
+    - '!**/*.xml'
+    - '!**/*.md'
+    - '!**/*.bats'
+chat:
+  auto_reply: true

--- a/series/README.md
+++ b/series/README.md
@@ -1,0 +1,34 @@
+# Series
+
+Welcome to Series on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a string of digits, output all the contiguous substrings of length `n` in that string in the order that they appear.
+
+For example, the string "49142" has the following 3-digit series:
+
+- "491"
+- "914"
+- "142"
+
+And the following 4-digit series:
+
+- "4914"
+- "9142"
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve whatever you get.
+
+Note that these series are only required to occupy *adjacent positions* in the input;
+the digits need not be *numerically consecutive*.
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+A subset of the Problem 8 at Project Euler - https://projecteuler.net/problem=8

--- a/series/series.awk
+++ b/series/series.awk
@@ -1,0 +1,11 @@
+@include "assert"
+
+{
+    assert(NF, "series cannot be empty")
+    assert(len > 0 && len <= length($0), "invalid length")
+
+    n = $0
+    while (i++ <= length(n) - len)
+        $i = substr(n, i, len)
+    print
+}

--- a/series/test-series.bats
+++ b/series/test-series.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# local version: 1.0.0.0
+
+@test "slices of one from one" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    expected="1"
+    run gawk -f series.awk -v len=1 <<< 1
+    assert_success
+    assert_output "$expected"
+}
+
+@test "slices of one from two" {
+    expected="1 2"
+    run gawk -f series.awk -v len=1 <<< 12
+    assert_success
+    assert_output "$expected"
+}
+
+@test "slices of two" {
+    expected="35"
+    run gawk -f series.awk -v len=2 <<< 35
+    assert_success
+    assert_output "$expected"
+}
+
+@test "slices of two overlap" {
+    expected="91 14 42"
+    run gawk -f series.awk -v len=2 <<< 9142
+    assert_success
+    assert_output "$expected"
+}
+
+@test "slices can include duplicates" {
+    expected="777 777 777 777"
+    run gawk -f series.awk -v len=3 <<< 777777
+    assert_success
+    assert_output "$expected"
+}
+
+@test "slices of a long series" {
+    expected="91849 18493 84939 49390 93904 39042 90424 04243"
+    run gawk -f series.awk -v len=5 <<< 918493904243
+    assert_success
+    assert_output "$expected"
+}
+
+@test "slice length is too large" {
+    expected="invalid length"
+    run gawk -f series.awk -v len=6 <<< 12345
+    assert_failure
+    assert_output --partial "$expected"
+}
+
+@test "slice length is way too large" {
+    expected="invalid length"
+    run gawk -f series.awk -v len=42 <<< 12345
+    assert_failure
+    assert_output --partial "$expected"
+}
+
+@test "slice length cannot be zero" {
+    expected="invalid length"
+    run gawk -f series.awk -v len=0 <<< 12345
+    assert_failure
+    assert_output --partial "$expected"
+}
+
+@test "slice length cannot be negative" {
+    expected="invalid length"
+    run gawk -f series.awk -v len=-1 <<< 123
+    assert_failure
+    assert_output --partial "$expected"
+}
+
+@test "empty series is invalid" {
+    expected="series cannot be empty"
+    run gawk -f series.awk -v len=1 <<< ""
+    assert_failure
+    assert_output --partial "$expected"
+}


### PR DESCRIPTION
Added a new exercise for the AWK track, Series, to take a string of digits and output all contiguous substrings of a certain length. Included a series.awk script file with the solution and test-series.bats with a testing suite to validate the correct functionality of the solution script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced CodeRabbit integration with configuration settings for early access, review automation, chat auto-reply, and path filters.
	- Added functionality for extracting substrings from a series with validations for non-empty series and valid length parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->