### PR TITLE
Add 'Space Age' exercise in AWK

### DIFF
--- a/space-age/README.md
+++ b/space-age/README.md
@@ -1,0 +1,34 @@
+# Space Age
+
+Welcome to Space Age on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given an age in seconds, calculate how old someone would be on:
+
+- Mercury: orbital period 0.2408467 Earth years
+- Venus: orbital period 0.61519726 Earth years
+- Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
+- Mars: orbital period 1.8808158 Earth years
+- Jupiter: orbital period 11.862615 Earth years
+- Saturn: orbital period 29.447498 Earth years
+- Uranus: orbital period 84.016846 Earth years
+- Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31.69 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
+
+[pluto-video]: https://www.youtube.com/watch?v=Z_2gbGXzFbs
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. - https://pine.fm/LearnToProgram/?Chapter=01

--- a/space-age/space-age.awk
+++ b/space-age/space-age.awk
@@ -1,0 +1,20 @@
+BEGIN {
+    OFMT = "%.2f"
+    OrbitalPeriod["Earth"] = Earth = 31 557 600
+    OrbitalPeriod["Mercury"] = Earth * 0.2408467
+    OrbitalPeriod["Venus"] = 0.61519726 * Earth
+    OrbitalPeriod["Mars"] = 1.8808158 * Earth
+    OrbitalPeriod["Jupiter"] = 11.862615 * Earth
+    OrbitalPeriod["Saturn"] = 29.447498 * Earth
+    OrbitalPeriod["Uranus"] = 84.016846 * Earth
+    OrbitalPeriod["Neptune"] = 164.79132 * Earth
+}
+
+$1 in OrbitalPeriod {
+    print $2 / OrbitalPeriod[$1]
+    next
+}
+{
+    print $1, "is not a planet"
+    exit 1
+}

--- a/space-age/test-space-age.bats
+++ b/space-age/test-space-age.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# local version: 1.2.0.0
+
+@test "age on Earth" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f space-age.awk <<< "Earth 1000000000"
+    assert_success
+    assert_output 31.69
+}
+
+@test "age on Mercury" {
+    run gawk -f space-age.awk <<< "Mercury 2134835688"
+    assert_success
+    assert_output 280.88
+}
+
+@test "age on Venus" {
+    run gawk -f space-age.awk <<< "Venus 189839836"
+    assert_success
+    assert_output 9.78
+}
+
+@test "age on Mars" {
+    run gawk -f space-age.awk <<< "Mars 2129871239"
+    assert_success
+    assert_output 35.88
+}
+
+@test "age on Jupiter" {
+    run gawk -f space-age.awk <<< "Jupiter 901876382"
+    assert_success
+    assert_output 2.41
+}
+
+@test "age on Saturn" {
+    run gawk -f space-age.awk <<< "Saturn 2000000000"
+    assert_success
+    assert_output 2.15
+}
+
+@test "age on Uranus" {
+    run gawk -f space-age.awk <<< "Uranus 1210123456"
+    assert_success
+    assert_output 0.46
+}
+
+@test "age on Neptune" {
+    run gawk -f space-age.awk <<< "Neptune 1821023456"
+    assert_success
+    assert_output 0.35
+}
+
+@test "not a planet" {
+    run gawk -f space-age.awk <<< "Sun 680804807"
+    assert_failure
+    assert_output --partial "not a planet"
+}


### PR DESCRIPTION
The new 'Space Age' exercise is added with instructions, the main AWK script, and the related tests. The exercise calculates a person's age on different planets given their age in seconds, with specific tests to verify the validity of the inputs and results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to calculate a person's age in planetary years for various planets based on their Earth age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->