### PR TITLE
Add 'Sum of Multiples' exercise and tests

### DIFF
--- a/sum-of-multiples/README.md
+++ b/sum-of-multiples/README.md
@@ -1,0 +1,22 @@
+# Sum Of Multiples
+
+Welcome to Sum Of Multiples on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a number, find the sum of all the unique multiples of particular numbers up to but not including that number.
+
+If we list all the natural numbers below 20 that are multiples of 3 or 5, we get 3, 5, 6, 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.
+
+## Source
+
+### Created by
+
+- @IsaacG
+
+### Based on
+
+A variation on Problem 1 at Project Euler - https://projecteuler.net/problem=1

--- a/sum-of-multiples/sum-of-multiples.awk
+++ b/sum-of-multiples/sum-of-multiples.awk
@@ -1,0 +1,13 @@
+# These variables are initialized on the command line (using '-v'):
+# - limit
+
+{
+    for (n = 1; n < limit; ++n)
+        if (is_multiple(n)) sum += n
+    print +sum
+}
+
+function is_multiple(number,   i) {
+    for (i = NF; i > 0; --i)
+        if ($i && number % $i == 0) return 1
+}

--- a/sum-of-multiples/test-sum-of-multiples.bats
+++ b/sum-of-multiples/test-sum-of-multiples.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# local version: 1.5.0.0
+
+@test "no multiples within limit" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f sum-of-multiples.awk -v limit=1 <<< "3 5"
+    assert_success
+    assert_output "0"
+}
+
+@test "one factor has multiples within limit" {
+    run gawk -f sum-of-multiples.awk -v limit=4 <<< "3 5"
+    assert_success
+    assert_output "3"
+}
+
+@test "more than one multiple within limit" {
+    run gawk -f sum-of-multiples.awk -v limit=7 <<< "3"
+    assert_success
+    assert_output "9"
+}
+
+@test "more than one factor with multiples within limit" {
+    run gawk -f sum-of-multiples.awk -v limit=10 <<< "3 5"
+    assert_success
+    assert_output "23"
+}
+
+@test "each multiple is only counted once" {
+    run gawk -f sum-of-multiples.awk -v limit=100 <<< "3 5"
+    assert_success
+    assert_output "2318"
+}
+
+@test "a much larger limit" {
+    run gawk -f sum-of-multiples.awk -v limit=1000 <<< "3 5"
+    assert_success
+    assert_output "233168"
+}
+
+@test "three factors" {
+    run gawk -f sum-of-multiples.awk -v limit=20 <<< "7 13 17"
+    assert_success
+    assert_output "51"
+}
+
+@test "factors not relatively prime" {
+    run gawk -f sum-of-multiples.awk -v limit=15 <<< "4 6"
+    assert_success
+    assert_output "30"
+}
+
+@test "some pairs of factors relatively prime and some not" {
+    run gawk -f sum-of-multiples.awk -v limit=150 <<< "5 6 8"
+    assert_success
+    assert_output "4419"
+}
+
+@test "one factor is a multiple of another" {
+    run gawk -f sum-of-multiples.awk -v limit=51 <<< "5 25"
+    assert_success
+    assert_output "275"
+}
+
+@test "much larger factors" {
+    run gawk -f sum-of-multiples.awk -v limit=10000 <<< "43 47"
+    assert_success
+    assert_output "2203160"
+}
+
+@test "all numbers are multiples of 1" {
+    run gawk -f sum-of-multiples.awk -v limit=100 <<< "1"
+    assert_success
+    assert_output "4950"
+}
+
+@test "no factors means an empty sum" {
+    run gawk -f sum-of-multiples.awk -v limit=10000 <<< ""
+    assert_success
+    assert_output "0"
+}
+
+@test "the only multiple of 0 is 0" {
+    run gawk -f sum-of-multiples.awk -v limit=1 <<< "0"
+    assert_success
+    assert_output "0"
+}
+
+@test "the factor 0 does not affect the sum of multiples of other factors" {
+    run gawk -f sum-of-multiples.awk -v limit=4 <<< "3 0"
+    assert_success
+    assert_output "3"
+}
+
+@test "solutions using include-exclude must extend to cardinality greater than 3" {
+    run gawk -f sum-of-multiples.awk -v limit=10000 <<< "2 3 5 7 11"
+    assert_success
+    assert_output "39614537"
+}


### PR DESCRIPTION
This commit introduces the 'Sum of Multiples' exercise on the AWK Track of Exercism. It covers the main .awk script for determining the sum of unique multiples of given numbers, and accompanying tests to ensure the correct implementation and accurate results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a new script that calculates the sum of multiples of specified numbers up to a given limit.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->