### PR TITLE
Create new 'Tournament' exercise and tests

### DIFF
--- a/tournament/README.md
+++ b/tournament/README.md
@@ -1,0 +1,86 @@
+# Tournament
+
+Welcome to Tournament on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Tally the results of a small football competition.
+
+Based on an input file containing which team played against which and what the outcome was, create a file with a table like this:
+
+```text
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+Courageous Californians        |  3 |  0 |  1 |  2 |  1
+```
+
+What do those abbreviations mean?
+
+- MP: Matches Played
+- W: Matches Won
+- D: Matches Drawn (Tied)
+- L: Matches Lost
+- P: Points
+
+A win earns a team 3 points.
+A draw earns 1.
+A loss earns 0.
+
+The outcome is ordered by points, descending.
+In case of a tie, teams are ordered alphabetically.
+
+## Input
+
+Your tallying program will receive input that looks like:
+
+```text
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Courageous Californians;draw
+Devastating Donkeys;Allegoric Alaskans;win
+Courageous Californians;Blithering Badgers;loss
+Blithering Badgers;Devastating Donkeys;loss
+Allegoric Alaskans;Courageous Californians;win
+```
+
+The result of the match refers to the first team listed.
+So this line:
+
+```text
+Allegoric Alaskans;Blithering Badgers;win
+```
+
+means that the Allegoric Alaskans beat the Blithering Badgers.
+
+This line:
+
+```text
+Courageous Californians;Blithering Badgers;loss
+```
+
+means that the Blithering Badgers beat the Courageous Californians.
+
+And this line:
+
+```text
+Devastating Donkeys;Courageous Californians;draw
+```
+
+means that the Devastating Donkeys and Courageous Californians tied.
+
+## Sorting in AWK
+
+Refer to the [`high-scores` exercise instructions][high-score]
+for a discussion on sorting techniques.
+
+For this exercise, a user-defined sorting function is warranted.
+
+[high-score]: https://exercism.org/tracks/awk/exercises/high-scores
+
+## Source
+
+### Created by
+
+- @IsaacG

--- a/tournament/test-tournament.bats
+++ b/tournament/test-tournament.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# Assert that running the program with input $1 generates output $2.
+assert_in_to_out() {
+    run gawk -f tournament.awk <<< "$1"
+    assert_success
+    assert_output "$2"
+}
+
+@test "just the header if no input" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input=""
+
+    expected="Team                           | MP |  W |  D |  L |  P"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "a win is three points, a loss is zero points" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="Allegoric Alaskans;Blithering Badgers;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+Blithering Badgers             |  1 |  0 |  0 |  1 |  0"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "a win can also be expressed as a loss" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="Blithering Badgers;Allegoric Alaskans;loss"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+Blithering Badgers             |  1 |  0 |  0 |  1 |  0"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "a different team can win" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="Blithering Badgers;Allegoric Alaskans;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Blithering Badgers             |  1 |  1 |  0 |  0 |  3
+Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "a draw is one point each" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="Allegoric Alaskans;Blithering Badgers;draw"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
+Blithering Badgers             |  1 |  0 |  1 |  0 |  1"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "There can be more than one match" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Allegoric Alaskans;Blithering Badgers;win
+Allegoric Alaskans;Blithering Badgers;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+Blithering Badgers             |  2 |  0 |  0 |  2 |  0"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "There can be more than one winner" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Allegoric Alaskans;Blithering Badgers;loss
+Allegoric Alaskans;Blithering Badgers;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
+Blithering Badgers             |  2 |  1 |  0 |  1 |  3"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "There can be more than two teams" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Allegoric Alaskans;Blithering Badgers;win
+Blithering Badgers;Courageous Californians;win
+Courageous Californians;Allegoric Alaskans;loss"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+Courageous Californians        |  2 |  0 |  0 |  2 |  0"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "typical input" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Courageous Californians;draw
+Devastating Donkeys;Allegoric Alaskans;win
+Courageous Californians;Blithering Badgers;loss
+Blithering Badgers;Devastating Donkeys;loss
+Allegoric Alaskans;Courageous Californians;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+Courageous Californians        |  3 |  0 |  1 |  2 |  1"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "incomplete competition (not all pairs have played)" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Allegoric Alaskans;Blithering Badgers;loss
+Devastating Donkeys;Allegoric Alaskans;loss
+Courageous Californians;Blithering Badgers;draw
+Allegoric Alaskans;Courageous Californians;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  2 |  1 |  1 |  0 |  4
+Courageous Californians        |  2 |  0 |  1 |  1 |  1
+Devastating Donkeys            |  1 |  0 |  0 |  1 |  0"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "ties broken alphabetically" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Courageous Californians;Devastating Donkeys;win
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Allegoric Alaskans;loss
+Courageous Californians;Blithering Badgers;win
+Blithering Badgers;Devastating Donkeys;draw
+Allegoric Alaskans;Courageous Californians;draw"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
+Courageous Californians        |  3 |  2 |  1 |  0 |  7
+Blithering Badgers             |  3 |  0 |  1 |  2 |  1
+Devastating Donkeys            |  3 |  0 |  1 |  2 |  1"
+
+    assert_in_to_out "$input" "$expected"
+}
+
+@test "ensure points sorted numerically" {
+
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    input="\
+Devastating Donkeys;Blithering Badgers;win
+Devastating Donkeys;Blithering Badgers;win
+Devastating Donkeys;Blithering Badgers;win
+Devastating Donkeys;Blithering Badgers;win
+Blithering Badgers;Devastating Donkeys;win"
+
+    expected="\
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
+Blithering Badgers             |  5 |  1 |  0 |  4 |  3"
+
+    assert_in_to_out "$input" "$expected"
+}

--- a/tournament/tournament.awk
+++ b/tournament/tournament.awk
@@ -1,0 +1,40 @@
+BEGIN {
+    FS = ";"
+}
+!NF {next}
+{
+    Teams[$1]["MP"]++
+    Teams[$2]["MP"]++
+}
+$3 == "win" {
+    Teams[$1]["W"]++
+    Teams[$2]["L"]++
+    Teams[$1]["P"]+=3
+}
+$3 == "loss" {
+    Teams[$2]["W"]++
+    Teams[$1]["L"]++
+    Teams[$2]["P"]+=3
+}
+$3 == "draw" {
+    Teams[$1]["D"]++
+    Teams[$2]["D"]++
+    Teams[$1]["P"]++
+    Teams[$2]["P"]++
+}
+END {
+    print "Team                           | MP |  W |  D |  L |  P"
+    PROCINFO["sorted_in"] = "compare"
+    for (team in Teams)
+        printf("%-30s | %2d | %2d | %2d | %2d | %2d\n", team,\
+            Teams[team]["MP"],\
+            Teams[team]["W"],\
+            Teams[team]["D"],\
+            Teams[team]["L"],\
+            Teams[team]["P"])
+}
+
+function compare(name1, one, name2, two) {
+    if (one["P"] == two["P"]) return name1 > name2
+    return one["P"] < two["P"] ? 1 : -1
+}


### PR DESCRIPTION
This commit introduces a new exercise called 'Tournament' for the AWK track on Exercism. This exercise challenges users to tally the results of a football competition, given an input of team matchups and their outcomes. BATS tests are provided to verify the correctness of user submissions.