### PR TITLE
Add word count exercise in AWK

### DIFF
--- a/word-count/README.md
+++ b/word-count/README.md
@@ -1,0 +1,46 @@
+# Word Count
+
+Welcome to Word Count on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a phrase, count the occurrences of each _word_ in that phrase.
+
+For the purposes of this exercise you can expect that a _word_ will always be one of:
+
+1. A _number_ composed of one or more ASCII digits (ie "0" or "1234") OR
+2. A _simple word_ composed of one or more ASCII letters (ie "a" or "they") OR
+3. A _contraction_ of two _simple words_ joined by a single apostrophe (ie "it's" or "they're")
+
+When counting words you can assume the following rules:
+
+1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
+2. The count is _unordered_; the tests will ignore how words and counts are ordered
+3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are regarded as spaces
+4. The words can be separated by _any_ form of whitespace (ie "\t", "\n", " ")
+
+For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:
+
+```text
+that's: 1
+the: 2
+password: 2
+123: 1
+cried: 1
+special: 1
+agent: 1
+so: 1
+i: 1
+fled: 1
+```
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.

--- a/word-count/test-word-count.bats
+++ b/word-count/test-word-count.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# The `assert_line` test does not care about _order_, just that the line
+# exists in the output.
+
+@test "count one word" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f word-count.awk <<< "word"
+    assert_success
+    assert_line "word: 1"
+    assert_equal "${#lines[@]}" 1
+}
+
+@test "count one of each word" {
+    run gawk -f word-count.awk <<< "one of each"
+    assert_success
+    assert_line "one: 1"
+    assert_line "of: 1"
+    assert_line "each: 1"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "multiple occurrences of a word" {
+    run gawk -f word-count.awk <<< "one fish two fish red fish blue fish"
+    assert_success
+    assert_line "one: 1"
+    assert_line "fish: 4"
+    assert_line "two: 1"
+    assert_line "red: 1"
+    assert_line "blue: 1"
+    assert_equal "${#lines[@]}" 5
+}
+
+@test "handles cramped lists" {
+    run gawk -f word-count.awk <<< "one,two,three"
+    assert_success
+    assert_line "one: 1"
+    assert_line "two: 1"
+    assert_line "three: 1"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "handles expanded lists" {
+    run gawk -f word-count.awk << END_INPUT
+one,
+two,
+three
+END_INPUT
+    assert_success
+    assert_line "one: 1"
+    assert_line "two: 1"
+    assert_line "three: 1"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "ignore punctuation" {
+    run gawk -f word-count.awk <<< "car: carpet as java: javascript!!&@$%^&"
+    assert_success
+    assert_line "car: 1"
+    assert_line "carpet: 1"
+    assert_line "as: 1"
+    assert_line "java: 1"
+    assert_line "javascript: 1"
+    assert_equal "${#lines[@]}" 5
+}
+
+@test "include numbers" {
+    run gawk -f word-count.awk <<< "testing, 1, 2 testing"
+    assert_success
+    assert_line "testing: 2"
+    assert_line "1: 1"
+    assert_line "2: 1"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "normalize case" {
+    run gawk -f word-count.awk <<< "go Go GO Stop stop"
+    assert_success
+    assert_line "go: 3"
+    assert_line "stop: 2"
+    assert_equal "${#lines[@]}" 2
+}
+
+@test "with apostrophes" {
+    run gawk -f word-count.awk <<< "'First: don't laugh. Then: don't cry. You're getting it.'"
+    assert_success
+    assert_line "first: 1"
+    assert_line "don't: 2"
+    assert_line "laugh: 1"
+    assert_line "then: 1"
+    assert_line "cry: 1"
+    assert_line "you're: 1"
+    assert_line "getting: 1"
+    assert_line "it: 1"
+    assert_equal "${#lines[@]}" 8
+}
+
+@test "with quotations" {
+    run gawk -f word-count.awk <<< "Joe can't tell between 'large' and large."
+    assert_success
+    assert_line "joe: 1"
+    assert_line "can't: 1"
+    assert_line "tell: 1"
+    assert_line "between: 1"
+    assert_line "large: 2"
+    assert_line "and: 1"
+    assert_equal "${#lines[@]}" 6
+}
+
+@test "substrings from the beginning" {
+    run gawk -f word-count.awk <<< "Joe can't tell between apple, app and a."
+    assert_success
+    assert_line "joe: 1"
+    assert_line "can't: 1"
+    assert_line "tell: 1"
+    assert_line "apple: 1"
+    assert_line "app: 1"
+    assert_line "and: 1"
+    assert_line "a: 1"
+    assert_equal "${#lines[@]}" 8
+}
+
+@test "multiple spaces not detected as a word" {
+    run gawk -f word-count.awk <<< " multiple   whitespaces"
+    assert_success
+    assert_line "multiple: 1"
+    assert_line "whitespaces: 1"
+    assert_equal "${#lines[@]}" 2
+}
+
+@test "alternating word separators are not detected as a word" {
+    run gawk -f word-count.awk <<< $',\n,one,\n ,two \n \'three\''
+    assert_success
+    assert_line "one: 1"
+    assert_line "two: 1"
+    assert_line "three: 1"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "quotation for word with apostrophe" {
+    run gawk -f word-count.awk <<< "can, can't, 'can't'"
+    assert_success
+    assert_line "can: 1"
+    assert_line "can't: 2"
+    assert_equal "${#lines[@]}" 2
+}

--- a/word-count/word-count.awk
+++ b/word-count/word-count.awk
@@ -1,0 +1,10 @@
+BEGIN {
+    FPAT = "[[:digit:]]+|[[:alpha:]]+('[[:alpha:]]+)?"
+    OFS = ": "
+}
+{
+    for (i = 1; i <= NF; ++i) Words[tolower($i)]++
+}
+END {
+    for (word in Words) print word, Words[word]
+}


### PR DESCRIPTION
Created a new exercise named "Word Count" in AWK. This includes a main script, which counts the occurrences of each word in a given phrase (with special handling for digits, contractions and simple words). The README file provides detailed instructions while the test file ensures proper functioning of the script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature to count and display the frequency of words in a text file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->