### PR TITLE
Add ETL exercise with test cases

### DIFF
--- a/etl/README.md
+++ b/etl/README.md
@@ -1,0 +1,61 @@
+# Etl
+
+Welcome to Etl on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+## ETL
+
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this once."
+That's then typically followed by much forehead slapping and moaning about how stupid we could possibly be.)
+
+## The goal
+
+We're going to extract some Scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new Scrabble system instead stores the score per letter, which makes it much faster and easier to calculate the score for a word.
+It also stores the letters in lower-case regardless of the case of the input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data format to the shiny new format.
+
+## Notes
+
+A final note about scoring, Scrabble is played around the world in a variety of languages, each with its own unique scoring table.
+For example, an "E" is scored at 2 in the Māori-language version of the game while being scored at 4 in the Hawaiian-language version.
+
+## About the tests
+
+AWK is very often used as an ETL tool (read the input, process it, and write a "report").
+Very often, in practice the input format is somewhat tricky.
+This exercise will try to mimic this, using inconsistent input formats that your program will have to normalize.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Exercise by the JumpstartLab team for students at The Turing School of Software and Design. - https://turing.edu

--- a/etl/etl.awk
+++ b/etl/etl.awk
@@ -1,0 +1,13 @@
+BEGIN {
+    FPAT = "[[:digit:]]{1,2}|[[:alpha:]]"
+    OFS = ","
+}
+{
+    for (i = 2; i <= NF; ++i)
+        Score[tolower($i)] = $1
+}
+END {
+    PROCINFO["sorted_in"] = "@ind_str_asc"
+    for (letter in Score)
+        print letter, Score[letter]
+}

--- a/etl/test-etl.bats
+++ b/etl/test-etl.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test 'single letter' {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f etl.awk << END_INPUT
+1: A
+END_INPUT
+
+    assert_success
+    assert_output "a,1"
+}
+
+@test 'single score with multiple letters' {
+    run gawk -f etl.awk << END_INPUT
+1:  "A", "E", "I", "O", "U"
+END_INPUT
+
+    assert_success
+    assert_line --index 0 -- "a,1"
+    assert_line --index 1 -- "e,1"
+    assert_line --index 2 -- "i,1"
+    assert_line --index 3 -- "o,1"
+    assert_line --index 4 -- "u,1"
+    assert_equal "${#lines[@]}" 5
+}
+
+@test 'a score with no letters' {
+    run gawk -f etl.awk << END_INPUT
+1: A
+7: 
+END_INPUT
+
+    assert_success
+    assert_output "a,1"
+}
+
+@test 'multiple scores with multiple letters' {
+    run gawk -f etl.awk << END_INPUT
+1:  "E", "A"
+2:"D","G"
+END_INPUT
+
+    assert_success
+    assert_line --index 0 -- "a,1"
+    assert_line --index 1 -- "d,2"
+    assert_line --index 2 -- "e,1"
+    assert_line --index 3 -- "g,2"
+    assert_equal "${#lines[@]}" 4
+}
+
+@test 'multiple scores with multiple letters, blank lines' {
+    run gawk -f etl.awk << END_INPUT
+
+2:"D","G"
+        
+1:  "E", "A"
+END_INPUT
+
+    assert_success
+    assert_line --index 0 -- "a,1"
+    assert_line --index 1 -- "d,2"
+    assert_line --index 2 -- "e,1"
+    assert_line --index 3 -- "g,2"
+    assert_equal "${#lines[@]}" 4
+}
+
+@test 'multiple scores with differing numbers of letters' {
+
+    # there are tab characters below
+    run gawk -f etl.awk << END_INPUT
+1:	"A", "E", "I", "O", "U", "L", "N", "R", "S", "T"
+2:	"D", "G"
+4:	"F", "H", "V", "W", "Y"
+3:	"m", "B", "C", "P"
+5:	"K"
+8:	"J", "X"
+10:	"Q", "Z"
+END_INPUT
+
+    assert_success
+    assert_line --index  0 -- a,1
+    assert_line --index  1 -- b,3
+    assert_line --index  2 -- c,3
+    assert_line --index  3 -- d,2
+    assert_line --index  4 -- e,1
+    assert_line --index  5 -- f,4
+    assert_line --index  6 -- g,2
+    assert_line --index  7 -- h,4
+    assert_line --index  8 -- i,1
+    assert_line --index  9 -- j,8
+    assert_line --index 10 -- k,5
+    assert_line --index 11 -- l,1
+    assert_line --index 12 -- m,3
+    assert_line --index 13 -- n,1
+    assert_line --index 14 -- o,1
+    assert_line --index 15 -- p,3
+    assert_line --index 16 -- q,10
+    assert_line --index 17 -- r,1
+    assert_line --index 18 -- s,1
+    assert_line --index 19 -- t,1
+    assert_line --index 20 -- u,1
+    assert_line --index 21 -- v,4
+    assert_line --index 22 -- w,4
+    assert_line --index 23 -- x,8
+    assert_line --index 24 -- y,4
+    assert_line --index 25 -- z,10
+    assert_equal "${#lines[@]}" 26
+}


### PR DESCRIPTION
Implemented the new ETL exercise in the AWK track. This exercise involves the 'Transform' step of Extract-Transform-Load, with a focus on transforming Scrabble scores from a legacy system to a more efficient format. Also included detailed instructions in README and related tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to process input data and generate a sorted list of letters with their corresponding scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->