### PR TITLE
Add Forth script evaluator and tests

### DIFF
--- a/forth/README.md
+++ b/forth/README.md
@@ -1,0 +1,34 @@
+# Forth
+
+Welcome to Forth on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Implement an evaluator for a very simple subset of Forth.
+
+[Forth][forth]
+is a stack-based programming language.
+Implement a very basic evaluator for a small subset of Forth.
+
+Your evaluator has to support the following words:
+
+- `+`, `-`, `*`, `/` (integer arithmetic)
+- `DUP`, `DROP`, `SWAP`, `OVER` (stack manipulation)
+
+Your evaluator also has to support defining new words using the customary syntax: `: word-name definition ;`.
+
+To keep things simple the only data type you need to support is signed integers of at least 16 bits size.
+
+You should use the following rules for the syntax: a number is a sequence of one or more (ASCII) digits, a word is a sequence of one or more letters, digits, symbols or punctuation that is not a number.
+(Forth probably uses slightly different rules, but this is close enough.)
+
+Words are case-insensitive.
+
+[forth]: https://en.wikipedia.org/wiki/Forth_%28programming_language%29
+
+## Source
+
+### Created by
+
+- @glennj

--- a/forth/forth.awk
+++ b/forth/forth.awk
@@ -1,0 +1,77 @@
+BEGIN {
+    Number = @/-?[[:digit:]]+/
+    BiOperator = @/[-+*]|[/]|swap|over/
+}
+
+BEGINFILE {
+    delete Stack
+    delete Macro
+    Size = 0
+}
+{
+    $0 = tolower($0)
+}
+$1 == ":" {
+    if ($NF != ";") die("macro not terminated with semicolon")
+    if (NF < 4) die("empty macro definition")
+    if ($2 ~ Number) die("illegal operation")
+    name = $2
+    $1 = $2 = $NF = ""
+    for (i = 3; i < NF; ++i) if ($i in Macro) $i = Macro[$i]
+    Macro[name] = $0
+    next
+}
+{
+    for (i = 1; i <= NF; ++i) {
+        if ($i ~ Number) push($i)
+        else if ($i in Macro) {
+            $i = Macro[$i]
+            $0 = $0
+            --i
+        } else if ($i ~ BiOperator) {
+            required(2)
+            b = pop()
+            a = pop()
+            switch ($i) {
+                case "+": push(a + b); break
+                case "-": push(a - b); break
+                case "*": push(a * b); break
+                case "/":
+                    if (!b) die("divide by zero")
+                    push(int(a / b)); break
+                case "swap": push(b); push(a); break
+                case "over": push(a); push(b); push(a); break
+            }
+        } else if ($i ~ /dup|drop/) {
+            required(1)
+            a = pop()
+            if ($i == "dup") {
+                push(a); push(a);
+            }
+        } else die("undefined operation")
+    }
+}
+
+ENDFILE {
+    NF = Size
+    while (Size) {
+        $Size = Stack[Size]
+        --Size
+    }
+    print
+}
+
+function die(message) {print message > "/dev/stderr"; exit 1}
+
+function required(n) {
+    if (!Size) print "empty stack"
+    else if (n > 1 && Size == 1) print "only one value on the stack"
+    else return
+    exit 1
+}
+function push(element) {
+    Stack[++Size] = element
+}
+function pop() {
+    return Stack[Size--]
+}

--- a/forth/test-forth.bats
+++ b/forth/test-forth.bats
@@ -1,0 +1,441 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# parsing and numbers
+@test numbers_only {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f forth.awk <<END
+1 2 3 4 5
+END
+    assert_success
+    assert_output "1 2 3 4 5"
+}
+
+@test "pushes negative numbers onto the stack" {
+    run gawk -f forth.awk <<END
+-1 -2 -3 -4 -5
+END
+    assert_success
+    assert_output "-1 -2 -3 -4 -5"
+}
+
+# addition
+@test addition_ok {
+    run gawk -f forth.awk <<END
+1 2 +
+END
+    assert_success
+    assert_output "3"
+}
+
+@test addition_no_args {
+    run gawk -f forth.awk <<END
++
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+@test addition_one_args {
+    run gawk -f forth.awk <<END
+1 +
+END
+    assert_failure
+    assert_output --partial "only one value on the stack"
+}
+
+# subtraction
+@test subtraction_ok {
+    run gawk -f forth.awk <<END
+3 4 -
+END
+    assert_success
+    assert_output "-1"
+}
+
+@test subtraction_no_args {
+    run gawk -f forth.awk <<END
+-
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+@test subtraction_one_args {
+    run gawk -f forth.awk <<END
+1 -
+END
+    assert_failure
+    assert_output --partial "only one value on the stack"
+}
+
+# multiplication
+@test multiplication_ok {
+    run gawk -f forth.awk <<END
+2 4 *
+END
+    assert_success
+    assert_output "8"
+}
+
+@test multiplication_no_args {
+    run gawk -f forth.awk <<END
+*
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+@test multiplication_one_args {
+    run gawk -f forth.awk <<END
+1 *
+END
+    assert_failure
+    assert_output --partial "only one value on the stack"
+}
+
+# division
+@test division_ok {
+    run gawk -f forth.awk <<END
+12 4 /
+END
+    assert_success
+    assert_output "3"
+}
+
+@test division_int_result {
+    run gawk -f forth.awk <<END
+8 3 /
+END
+    assert_success
+    assert_output "2"
+}
+
+@test division_no_args {
+    run gawk -f forth.awk <<END
+/
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+@test division_one_args {
+    run gawk -f forth.awk <<END
+1 /
+END
+    assert_failure
+    assert_output --partial "only one value on the stack"
+}
+
+@test division_by_zero {
+    run gawk -f forth.awk <<END
+2 0 /
+END
+    assert_failure
+    assert_output --partial "divide by zero"
+}
+
+# combined arithmetic
+@test add_and_subtract {
+    run gawk -f forth.awk <<END
+1 2 + 4 -
+END
+    assert_success
+    assert_output "-1"
+}
+@test multiply_and_divide {
+    run gawk -f forth.awk <<END
+2 4 * 3 /
+END
+    assert_success
+    assert_output "2"
+}
+
+# dup
+@test dup_1 {
+    run gawk -f forth.awk <<END
+1 dup
+END
+    assert_success
+    assert_output "1 1"
+}
+
+@test dup_2 {
+    run gawk -f forth.awk <<END
+1 2 dup
+END
+    assert_success
+    assert_output "1 2 2"
+}
+
+@test dup_empty {
+    run gawk -f forth.awk <<END
+dup
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+# drop
+@test drop_1 {
+    run gawk -f forth.awk <<END
+1 drop
+END
+    assert_success
+    assert_output ""
+}
+
+@test drop_2 {
+    run gawk -f forth.awk <<END
+1 2 drop
+END
+    assert_success
+    assert_output "1"
+}
+
+@test drop_empty {
+    run gawk -f forth.awk <<END
+drop
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+# swap
+@test swap_1 {
+    run gawk -f forth.awk <<END
+1 2 swap
+END
+    assert_success
+    assert_output "2 1"
+}
+
+@test swap_2 {
+    run gawk -f forth.awk <<END
+1 2 3 swap
+END
+    assert_success
+    assert_output "1 3 2"
+}
+
+@test swap_empty {
+    run gawk -f forth.awk <<END
+swap
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+@test swap_1arg {
+    run gawk -f forth.awk <<END
+1 swap
+END
+    assert_failure
+    assert_output --partial "only one value on the stack"
+}
+
+# over
+@test over_1 {
+    run gawk -f forth.awk <<END
+1 2 over
+END
+    assert_success
+    assert_output "1 2 1"
+}
+
+@test over_2 {
+    run gawk -f forth.awk <<END
+1 2 3 over
+END
+    assert_success
+    assert_output "1 2 3 2"
+}
+
+@test over_empty {
+    run gawk -f forth.awk <<END
+over
+END
+    assert_failure
+    assert_output --partial "empty stack"
+}
+
+@test over_1arg {
+    run gawk -f forth.awk <<END
+1 over
+END
+    assert_failure
+    assert_output --partial "only one value on the stack"
+}
+
+# user-defined words
+@test macro_with_builtin {
+    run gawk -f forth.awk <<END
+: dup-twice dup dup ;
+1 dup-twice
+END
+    assert_success
+    assert_output "1 1 1"
+}
+
+@test macro_maintain_order {
+    run gawk -f forth.awk <<END
+: countup 1 2 3 ;
+countup
+END
+    assert_success
+    assert_output "1 2 3"
+}
+
+@test macro_can_override_macro {
+    run gawk -f forth.awk <<END
+: foo dup ;
+: foo dup dup ;
+1 foo
+END
+    assert_success
+    assert_output "1 1 1"
+}
+
+@test macro_can_override_builtin {
+    run gawk -f forth.awk <<END
+: swap dup ;
+1 swap
+END
+    assert_success
+    assert_output "1 1"
+}
+
+@test macro_can_override_operator {
+    run gawk -f forth.awk <<END
+: + * ;
+3 4 +
+END
+    assert_success
+    assert_output "12"
+}
+
+@test macro_expand_in_macro_definition {
+    run gawk -f forth.awk <<END
+: foo 5 ;
+: bar foo ;
+: foo 6 ;
+bar foo
+END
+    assert_success
+    assert_output "5 6"
+}
+
+@test macro_empty_definition {
+    run gawk -f forth.awk <<END
+: foo ;
+END
+    assert_failure
+    assert_output --partial "empty macro definition"
+}
+
+@test macro_expand_in_macro_redefinition {
+    run gawk -f forth.awk <<END
+: foo 10 ;
+: foo foo 1 + ;
+foo
+END
+    assert_success
+    assert_output "11"
+}
+
+@test macro_cannot_redefine_non_negative_numbers {
+    run gawk -f forth.awk <<END
+: 1 2 ;
+END
+    assert_failure
+    assert_output --partial "illegal operation"
+}
+
+@test macro_cannot_redefine_negative_numbers {
+    run gawk -f forth.awk <<END
+: -1 2 ;
+END
+    assert_failure
+    assert_output --partial "illegal operation"
+}
+
+@test macro_undefined {
+    run gawk -f forth.awk <<END
+foo
+END
+    assert_failure
+    assert_output --partial "undefined operation"
+}
+
+@test macro_missing_semicolon {
+    run gawk -f forth.awk <<END
+: foo 1
+foo
+END
+    assert_failure
+    assert_output --partial "macro not terminated with semicolon"
+}
+
+# each file gets it's own forth evaluator: 
+# a stack and macros, and prints the stack at the end of the file
+@test each_file_gets_its_own_forth {
+    echo ': + - ;' >  first.txt
+    echo '1 1 +'   >> first.txt
+    echo '1 1 +'   >  second.txt
+    run gawk -f forth.awk first.txt second.txt
+    assert_success
+    assert_line --index 0 "0"
+    assert_line --index 1 "2"
+    rm -f first.txt second.txt
+}
+
+# case insensitivity
+@test case_dup {
+    run gawk -f forth.awk <<END
+1 DUP Dup dup
+END
+    assert_success
+    assert_output "1 1 1 1"
+}
+
+@test case_drop {
+    run gawk -f forth.awk <<END
+1 2 3 4 DROP DrOp drop
+END
+    assert_success
+    assert_output "1"
+}
+
+@test case_swap {
+    run gawk -f forth.awk <<END
+1 2 SWAP 3 Swap 4 swap
+END
+    assert_success
+    assert_output "2 3 4 1"
+}
+
+@test case_over {
+    run gawk -f forth.awk <<END
+1 2 OVER Over over
+END
+    assert_success
+    assert_output "1 2 1 2 1"
+}
+
+@test case_macro_names {
+    run gawk -f forth.awk <<END
+: foo dup ;
+1 FOO Foo foo
+END
+    assert_success
+    assert_output "1 1 1 1"
+}
+
+@test case_macro_definitions {
+    run gawk -f forth.awk <<END
+: SWAP DUP Dup dup ;
+1 swap
+END
+    assert_success
+    assert_output "1 1 1 1"
+}


### PR DESCRIPTION
Implemented an evaluator for a subset of the Forth programming language. The evaluator supports basic integer arithmetic and stack manipulation. It also allows defining new words using customary syntax. Tests covering basic functionality are included.