### PR TITLE
Add gigasecond calculation and tests

### DIFF
--- a/gigasecond/README.md
+++ b/gigasecond/README.md
@@ -1,0 +1,28 @@
+# Gigasecond
+
+Welcome to Gigasecond on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a moment, determine the moment that would be after a gigasecond has passed.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+## Time functions
+
+This exercise requires using GNU awk's [Time Functions][time-func].
+
+For the datetime parsing and formatting functions, be sure to set the UTC flag.
+
+[time-func]: https://www.gnu.org/software/gawk/manual/html_node/Time-Functions.html
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. - https://pine.fm/LearnToProgram/?Chapter=09

--- a/gigasecond/gigasecond.awk
+++ b/gigasecond/gigasecond.awk
@@ -1,0 +1,11 @@
+BEGIN {
+    GigaSecond = 1e9
+    FS = "[-T:]"
+}
+NF == 3 {
+    $4 = $5 = $6 = "00"
+}
+{
+    epoch = mktime($1" "$2" "$3" "$4" "$5" "$6, 1)
+    print strftime("%FT%T", epoch + GigaSecond, 1)
+}

--- a/gigasecond/test-gigasecond.bats
+++ b/gigasecond/test-gigasecond.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# Ensure your date calculations are done using UTC time zone
+
+@test 'date only specificaion of time' {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f gigasecond.awk <<< '2011-04-25'
+
+  assert_success
+  assert_output "2043-01-01T01:46:40"
+}
+
+@test 'second test for date only specification of time' {
+  run gawk -f gigasecond.awk <<< '1977-06-13'
+
+  assert_success
+  assert_output "2009-02-19T01:46:40"
+}
+
+@test 'third test for date only specification of time' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run gawk -f gigasecond.awk <<< '1959-07-19'
+
+  assert_success
+  assert_output "1991-03-27T01:46:40"
+}
+
+@test 'full time specified' {
+  run gawk -f gigasecond.awk <<< '2015-01-24T22:00:00'
+
+  assert_success
+  assert_output "2046-10-02T23:46:40"
+}
+
+@test 'full time with day roll-over' {
+  run gawk -f gigasecond.awk <<< '2015-01-24T23:59:59'
+
+  assert_success
+  assert_output "2046-10-03T01:46:39"
+}


### PR DESCRIPTION
This commit introduces a new AWK script that calculates the date and time after a gigasecond from a given moment. It also provides a test suite for this script to verify its accuracy in various scenarios. Finally, it includes a README file that provides instructions and resources on the exercise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to calculate the time after adding a gigasecond (1 billion seconds) to any provided timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->