### PR TITLE
Add isogram detection functionality and related tests

### DIFF
--- a/isogram/README.md
+++ b/isogram/README.md
@@ -1,0 +1,14 @@
+# Description
+
+Determine if a word or phrase is an isogram.
+
+An isogram (also known as a "non-pattern word") is a word or phrase without a repeating letter, however spaces and hyphens are allowed to appear multiple times.
+
+Examples of isograms:
+
+- lumberjacks
+- background
+- downstream
+- six-year-old
+
+The word _isograms_, however, is not an isogram, because the s repeats.

--- a/isogram/isogram.awk
+++ b/isogram/isogram.awk
@@ -2,14 +2,14 @@ BEGIN {
     FPAT = "[[:alpha:]]"
 }
 {
-    previous_letters = ""
+    delete Letters
     for (i = NF; i; --i) {
         letter = tolower($i)
-        if (index(previous_letters, letter)) {
+        if (Letters[letter]) {
             print "false"
             next
         }
-        previous_letters = previous_letters letter
+        Letters[letter] = 1
     }
     print "true"
 }

--- a/isogram/isogram.awk
+++ b/isogram/isogram.awk
@@ -1,0 +1,15 @@
+BEGIN {
+    FPAT = "[[:alpha:]]"
+}
+{
+    previous_letters = ""
+    for (i = NF; i; --i) {
+        letter = tolower($i)
+        if (index(previous_letters, letter)) {
+            print "false"
+            next
+        }
+        previous_letters = previous_letters letter
+    }
+    print "true"
+}

--- a/isogram/test-isogram.bats
+++ b/isogram/test-isogram.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "empty string" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< ""
+
+    assert_success
+    assert_output "true"
+}
+
+@test "isogram with only lower case characters" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "isogram"
+
+    assert_success
+    assert_output "true"
+}
+
+@test "word with one duplicated character" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "eleven"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "word with one duplicated character from the end of the alphabet" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "zzyzx"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "longest reported english isogram" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "subdermatoglyphic"
+
+    assert_success
+    assert_output "true"
+}
+
+@test "word with duplicated character in mixed case" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "Alphabet"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "word with duplicated character in mixed case, lowercase first" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "alphAbet"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "hypothetical isogrammic word with hyphen" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "thumbscrew-japingly"
+
+    assert_success
+    assert_output "true"
+}
+
+@test "hypothetical word with duplicated character following hyphen" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "thumbscrew-jappingly"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "isogram with duplicated hyphen" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "six-year-old"
+
+    assert_success
+    assert_output "true"
+}
+
+@test "made-up name that is an isogram" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "Emily Jung Schwartzkopf"
+
+    assert_success
+    assert_output "true"
+}
+
+@test "duplicated character in the middle" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "accentor"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "same first and last characters" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "angola"
+
+    assert_success
+    assert_output "false"
+}
+
+@test "word with duplicated character and with two hyphens" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f isogram.awk <<< "up-to-date"
+
+    assert_success
+    assert_output "false"
+}


### PR DESCRIPTION
This commit introduces a new functionality to detect if a given word or phrase is an isogram. A detailed README.md has been added to explain the concept. Furthermore, a comprehensive set of unit tests has been included to ensure the correct functionality of the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to check if a given word is an isogram, providing immediate feedback with "true" or "false".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->