### PR TITLE
Add 'grep' functionality and tests

### DIFF
--- a/grep/README.md
+++ b/grep/README.md
@@ -1,0 +1,104 @@
+# Grep
+
+Welcome to Grep on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Search a file for lines matching a regular expression pattern. Return the line
+number and contents of each matching line.
+
+The Unix [`grep`][grep] command can be used to search for lines in one or more files
+that match a user-provided search query (known as the *pattern*).
+
+The `grep` command takes three arguments:
+
+1. The pattern used to match lines in a file.
+2. Zero or more flags to customize the matching behavior.
+3. One or more files in which to search for matching lines.
+
+Your task is to implement the `grep` function: given a list of files, find all
+lines that match the specified pattern.
+Return the lines in the order they appear in the files.
+You'll also have to handle options (given as flags), which control how matching
+is done and how the results are to be reported.
+
+As an example, suppose there is a file named "input.txt" with the following contents:
+
+```text
+hello
+world
+hello again
+```
+
+If we were to call `grep "hello" input.txt`, the result should be:
+
+```text
+hello
+hello again
+```
+
+If given multiple files, `grep` should prefix each found line with the file it was found in.
+As an example:
+
+```text
+input.txt:hello
+input.txt:hello again
+greeting.txt:hello world
+```
+
+If given just one file, this prefix is not present.
+
+## Flags
+
+As said earlier, the `grep` command should also support the following flags:
+
+- `-n` Prefix each matching line with its line number within its file.
+  When multiple files are present, this prefix goes *after* the filename prefix.
+- `-l` Print only the names of files that contain at least one matching line.
+- `-i` Match line using a case-insensitive comparison.
+- `-v` Invert the program -- collect all lines that fail to match the pattern.
+- `-x` Only match entire lines, instead of lines that contain a match.
+
+If we run `grep -n "hello" input.txt`, the `-n` flag will require the matching
+lines to be prefixed with its line number:
+
+```text
+1:hello
+3:hello again
+```
+
+And if we run `grep -i "HELLO" input.txt`, we'll do a case-insensitive match,
+and the output will be:
+
+```text
+hello
+hello again
+```
+
+The `grep` command should support multiple flags at once.
+
+For example, running `grep -l -v "hello" file1.txt file2.txt` should
+print the names of files that do not contain the string "hello".
+
+[grep]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html
+
+## AWK-track adjustments to the requirements
+
+You are not forced to implement proper command line parsing: the flags are
+provided in a space-separated string that is straightforward to split apart.
+```sh
+gawk -f grep.awk -v flags="l v" -v pattern="hello" file1.txt file2.txt
+```
+
+Like real grep, your program will return a **non-zero exit status** when _no matches are found_.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Conversation with Nate Foster. - https://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf

--- a/grep/grep.awk
+++ b/grep/grep.awk
@@ -1,0 +1,23 @@
+# These variables are initialized on the command line (using '-v'):
+# - flags
+# - pattern
+
+BEGIN {
+    IGNORECASE = flags ~ /i/
+    if (flags ~ /x/) pattern = "^"pattern"$"
+}
+
+($0 ~ pattern) != (flags ~ /v/) {
+    Success = 1
+    if (flags ~ /l/) {
+        print FILENAME
+        nextfile
+    }
+    if (ARGC > 2) printf "%s:", FILENAME
+    if (flags ~ /n/) printf "%s:", FNR
+    print
+}
+
+END {
+    if (!Success) exit 1
+}

--- a/grep/test-grep.bats
+++ b/grep/test-grep.bats
@@ -1,0 +1,339 @@
+#!/usr/bin/env bats
+load bats-extra
+
+setup() {
+
+    cat > iliad.txt <<END_ILIAD
+Achilles sing, O Goddess! Peleus' son;
+His wrath pernicious, who ten thousand woes
+Caused to Achaia's host, sent many a soul
+Illustrious into Ades premature,
+And Heroes gave (so stood the will of Jove)
+To dogs and to all ravening fowls a prey,
+When fierce dispute had separated once
+The noble Chief Achilles from the son
+Of Atreus, Agamemnon, King of men.
+END_ILIAD
+
+    cat > midsummer-night.txt <<END_MIDSUMMER
+I do entreat your grace to pardon me.
+I know not by what power I am made bold,
+Nor how it may concern my modesty,
+In such a presence here to plead my thoughts;
+But I beseech your grace that I may know
+The worst that may befall me in this case,
+If I refuse to wed Demetrius.
+END_MIDSUMMER
+
+    cat > paradise-lost.txt <<END_PARADISE
+Of Mans First Disobedience, and the Fruit
+Of that Forbidden Tree, whose mortal tast
+Brought Death into the World, and all our woe,
+With loss of Eden, till one greater Man
+Restore us, and regain the blissful Seat,
+Sing Heav'nly Muse, that on the secret top
+Of Oreb, or of Sinai, didst inspire
+That Shepherd, who first taught the chosen Seed
+END_PARADISE
+}
+
+teardown() {
+    rm -f iliad.txt midsummer-night.txt paradise-lost.txt
+}
+
+# Test grepping a single file
+
+@test "One file, one match, no flags" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run gawk -f grep.awk -v pattern="Agamemnon" iliad.txt
+
+    assert_success
+    assert_output "Of Atreus, Agamemnon, King of men."
+}
+
+@test "One file, one match, print line numbers flag" {
+
+    run gawk -f grep.awk -v flags="n" -v pattern="Forbidden" paradise-lost.txt
+
+    assert_success
+    assert_output "2:Of that Forbidden Tree, whose mortal tast"
+}
+
+@test "One file, one match, case-insensitive flag" {
+
+    run gawk -f grep.awk -v flags="i" -v pattern="FORBIDDEN" paradise-lost.txt
+
+    assert_success
+    assert_output "Of that Forbidden Tree, whose mortal tast"
+}
+
+@test "One file, one match, print file names flag" {
+
+    run gawk -f grep.awk -v flags="l" -v pattern="Forbidden" paradise-lost.txt
+
+    assert_success
+    assert_output "paradise-lost.txt"
+}
+
+@test "One file, one match, match entire lines flag" {
+
+    run gawk -f grep.awk -v pattern="With loss of Eden, till one greater Man" paradise-lost.txt
+
+    assert_success
+    assert_output "With loss of Eden, till one greater Man"
+}
+
+@test "One file, one match, multiple flags" {
+
+    run gawk -f grep.awk -v flags="n i x" -v pattern="OF ATREUS, Agamemnon, KIng of MEN." iliad.txt
+
+    assert_success
+    assert_output "9:Of Atreus, Agamemnon, King of men."
+}
+
+@test "One file, several matches, no flags" {
+
+    run gawk -f grep.awk -v pattern="may" midsummer-night.txt
+
+    assert_success
+    assert_line --index 0 -- "Nor how it may concern my modesty,"
+    assert_line --index 1 -- "But I beseech your grace that I may know"
+    assert_line --index 2 -- "The worst that may befall me in this case,"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "One file, several matches, print line numbers flag" {
+
+    run gawk -f grep.awk -v flags="n" -v pattern="may" midsummer-night.txt
+
+    assert_success
+    assert_line --index 0 -- "3:Nor how it may concern my modesty,"
+    assert_line --index 1 -- "5:But I beseech your grace that I may know"
+    assert_line --index 2 -- "6:The worst that may befall me in this case,"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "One file, several matches, match entire lines flag" {
+
+    run gawk -f grep.awk -v flags="x" -v pattern="may" midsummer-night.txt
+
+    assert_failure
+    assert_output ""
+}
+
+@test "One file, several matches, case-insensitive flag" {
+
+    run gawk -f grep.awk -v flags="i" -v pattern="ACHILLES" iliad.txt
+
+    assert_success
+    assert_line --index 0 -- "Achilles sing, O Goddess! Peleus' son;"
+    assert_line --index 1 -- "The noble Chief Achilles from the son"
+    assert_equal "${#lines[@]}" 2
+}
+
+@test "One file, several matches, inverted flag" {
+
+    run gawk -f grep.awk -v flags="v" -v pattern="Of" paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "Brought Death into the World, and all our woe,"
+    assert_line --index 1 -- "With loss of Eden, till one greater Man"
+    assert_line --index 2 -- "Restore us, and regain the blissful Seat,"
+    assert_line --index 3 -- "Sing Heav'nly Muse, that on the secret top"
+    assert_line --index 4 -- "That Shepherd, who first taught the chosen Seed"
+    assert_equal "${#lines[@]}" 5
+}
+
+@test "One file, no matches, various flags" {
+
+    run gawk -f grep.awk -v flags="n l x i" -v pattern="Gandalf" iliad.txt
+
+    assert_failure
+    assert_output ""
+}
+
+@test "One file, one match, file flag takes precedence over line flag" {
+
+    run gawk -f grep.awk -v flags="n l" -v pattern="ten" iliad.txt
+
+    assert_success
+    assert_output "iliad.txt"
+}
+
+@test "One file, several matches, inverted and match entire lines flags" {
+
+    run gawk -f grep.awk -v flags="x v" -v pattern="Illustrious into Ades premature," iliad.txt
+
+    assert_success
+    assert_line --index 0 -- "Achilles sing, O Goddess! Peleus' son;"
+    assert_line --index 1 -- "His wrath pernicious, who ten thousand woes"
+    assert_line --index 2 -- "Caused to Achaia's host, sent many a soul"
+    assert_line --index 3 -- "And Heroes gave (so stood the will of Jove)"
+    assert_line --index 4 -- "To dogs and to all ravening fowls a prey,"
+    assert_line --index 5 -- "When fierce dispute had separated once"
+    assert_line --index 6 -- "The noble Chief Achilles from the son"
+    assert_line --index 7 -- "Of Atreus, Agamemnon, King of men."
+    assert_equal "${#lines[@]}" 8
+}
+
+# Multiple files
+
+@test "Multiple files, one match, no flags" {
+
+    run gawk -f grep.awk -v pattern="Agamemnon" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_output "iliad.txt:Of Atreus, Agamemnon, King of men."
+}
+
+@test "Multiple files, several matches, no flags" {
+
+    run gawk -f grep.awk -v pattern="may" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "midsummer-night.txt:Nor how it may concern my modesty,"
+    assert_line --index 1 -- "midsummer-night.txt:But I beseech your grace that I may know"
+    assert_line --index 2 -- "midsummer-night.txt:The worst that may befall me in this case,"
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "Multiple files, several matches, print line numbers flag" {
+
+    run gawk -f grep.awk -v flags="n" -v pattern="that" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "midsummer-night.txt:5:But I beseech your grace that I may know"
+    assert_line --index 1 -- "midsummer-night.txt:6:The worst that may befall me in this case,"
+    assert_line --index 2 -- "paradise-lost.txt:2:Of that Forbidden Tree, whose mortal tast"
+    assert_line --index 3 -- "paradise-lost.txt:6:Sing Heav'nly Muse, that on the secret top"
+    assert_equal "${#lines[@]}" 4
+}
+
+@test "Multiple files, one match, print file names flag" {
+
+    run gawk -f grep.awk -v flags="l" -v pattern="who" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "iliad.txt"
+    assert_line --index 1 -- "paradise-lost.txt"
+    assert_equal "${#lines[@]}" 2
+}
+
+@test "Multiple files, several matches, case-insensitive flag" {
+
+    run gawk -f grep.awk -v flags="i" -v pattern="TO" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "iliad.txt:Caused to Achaia's host, sent many a soul"
+    assert_line --index 1 -- "iliad.txt:Illustrious into Ades premature,"
+    assert_line --index 2 -- "iliad.txt:And Heroes gave (so stood the will of Jove)"
+    assert_line --index 3 -- "iliad.txt:To dogs and to all ravening fowls a prey,"
+    assert_line --index 4 -- "midsummer-night.txt:I do entreat your grace to pardon me."
+    assert_line --index 5 -- "midsummer-night.txt:In such a presence here to plead my thoughts;"
+    assert_line --index 6 -- "midsummer-night.txt:If I refuse to wed Demetrius."
+    assert_line --index 7 -- "paradise-lost.txt:Brought Death into the World, and all our woe,"
+    assert_line --index 8 -- "paradise-lost.txt:Restore us, and regain the blissful Seat,"
+    assert_line --index 9 -- "paradise-lost.txt:Sing Heav'nly Muse, that on the secret top"
+    assert_equal "${#lines[@]}" 10
+}
+
+@test "Multiple files, several matches, inverted flag" {
+
+    run gawk -f grep.awk -v flags="v" -v pattern="a" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "iliad.txt:Achilles sing, O Goddess! Peleus' son;"
+    assert_line --index 1 -- "iliad.txt:The noble Chief Achilles from the son"
+    assert_line --index 2 -- "midsummer-night.txt:If I refuse to wed Demetrius."
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "Multiple files, one match, match entire lines flag" {
+
+    run gawk -f grep.awk -v flags="x" -v pattern="But I beseech your grace that I may know" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_output "midsummer-night.txt:But I beseech your grace that I may know"
+}
+
+@test "Multiple files, one match, multiple flags" {
+
+    run gawk -f grep.awk -v flags="n i x" -v pattern="WITH LOSS OF EDEN, TILL ONE GREATER MAN" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_output "paradise-lost.txt:4:With loss of Eden, till one greater Man"
+}
+
+@test "Multiple files, no matches, various flags" {
+
+    run gawk -f grep.awk -v flags="n l i x" -v pattern="Frodo" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_failure
+    assert_output ""
+}
+
+@test "Multiple files, several matches, file flag takes precedence over line number flag" {
+
+    run gawk -f grep.awk -v flags="n l" -v pattern="who" iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "iliad.txt"
+    assert_line --index 1 -- "paradise-lost.txt"
+    assert_equal "${#lines[@]}" 2
+}
+
+@test "Multiple files, several matches, inverted and match entire lines flags" {
+
+    run gawk -f grep.awk -v flags="x v" -v pattern="Illustrious into Ades premature," iliad.txt midsummer-night.txt paradise-lost.txt
+
+    assert_success
+    assert_line --index 0 -- "iliad.txt:Achilles sing, O Goddess! Peleus' son;"
+    assert_line --index 1 -- "iliad.txt:His wrath pernicious, who ten thousand woes"
+    assert_line --index 2 -- "iliad.txt:Caused to Achaia's host, sent many a soul"
+    assert_line --index 3 -- "iliad.txt:And Heroes gave (so stood the will of Jove)"
+    assert_line --index 4 -- "iliad.txt:To dogs and to all ravening fowls a prey,"
+    assert_line --index 5 -- "iliad.txt:When fierce dispute had separated once"
+    assert_line --index 6 -- "iliad.txt:The noble Chief Achilles from the son"
+    assert_line --index 7 -- "iliad.txt:Of Atreus, Agamemnon, King of men."
+    assert_line --index 8 -- "midsummer-night.txt:I do entreat your grace to pardon me."
+    assert_line --index 9 -- "midsummer-night.txt:I know not by what power I am made bold,"
+    assert_line --index 10 -- "midsummer-night.txt:Nor how it may concern my modesty,"
+    assert_line --index 11 -- "midsummer-night.txt:In such a presence here to plead my thoughts;"
+    assert_line --index 12 -- "midsummer-night.txt:But I beseech your grace that I may know"
+    assert_line --index 13 -- "midsummer-night.txt:The worst that may befall me in this case,"
+    assert_line --index 14 -- "midsummer-night.txt:If I refuse to wed Demetrius."
+    assert_line --index 15 -- "paradise-lost.txt:Of Mans First Disobedience, and the Fruit"
+    assert_line --index 16 -- "paradise-lost.txt:Of that Forbidden Tree, whose mortal tast"
+    assert_line --index 17 -- "paradise-lost.txt:Brought Death into the World, and all our woe,"
+    assert_line --index 18 -- "paradise-lost.txt:With loss of Eden, till one greater Man"
+    assert_line --index 19 -- "paradise-lost.txt:Restore us, and regain the blissful Seat,"
+    assert_line --index 20 -- "paradise-lost.txt:Sing Heav'nly Muse, that on the secret top"
+    assert_line --index 21 -- "paradise-lost.txt:Of Oreb, or of Sinai, didst inspire"
+    assert_line --index 22 -- "paradise-lost.txt:That Shepherd, who first taught the chosen Seed"
+    assert_equal "${#lines[@]}" 23
+}
+
+# awk-specific tests: actual regular expressions
+
+@test "regular expression" {
+
+    run gawk -f grep.awk -v flags="i n" -v pattern="i.*d." midsummer-night.txt
+
+    assert_success
+    assert_line --index 0 -- "1:I do entreat your grace to pardon me."
+    assert_line --index 1 -- "2:I know not by what power I am made bold,"
+    assert_line --index 2 -- "3:Nor how it may concern my modesty,"
+    assert_line --index 3 -- "4:In such a presence here to plead my thoughts;"
+    assert_line --index 4 -- "7:If I refuse to wed Demetrius."
+    assert_equal "${#lines[@]}" 5
+}
+
+# awk-specific tests: actual regular expressions
+@test "same regular expression with -x flag" {
+
+    run gawk -f grep.awk -v flags="i n x" -v pattern="i.*d." midsummer-night.txt
+
+    assert_success
+    assert_output "2:I know not by what power I am made bold,"
+}


### PR DESCRIPTION
Implemented a 'grep' function in AWK, mimicking some of the original command's behaviors. Supports flags '-n', '-l', '-i', '-v', and '-x'. Test cases are included to validate correct functioning against these flags. Zero exit status is triggered with no matches to align with grep's usual behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new pattern matching functionality to enhance file searching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->