### PR TITLE
Add Hamming distance script and its tests

### DIFF
--- a/hamming/README.md
+++ b/hamming/README.md
@@ -1,0 +1,42 @@
+# Hamming
+
+Welcome to Hamming on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Calculate the Hamming Distance between two DNA strands.
+
+Your body is made up of cells that contain DNA.
+Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells.
+In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
+
+When cells divide, their DNA replicates too.
+Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information.
+If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred.
+This is known as the "Hamming Distance".
+
+We read DNA using the letters C,A,G and T.
+Two strands might look like this:
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+They have 7 differences, and therefore the Hamming Distance is 7.
+
+The Hamming Distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
+
+## Implementation notes
+
+The Hamming distance is only defined for sequences of equal length, so an attempt to calculate it between sequences of different lengths should not work.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+The Calculating Point Mutations problem at Rosalind - https://rosalind.info/problems/hamm/

--- a/hamming/hamming.awk
+++ b/hamming/hamming.awk
@@ -1,0 +1,13 @@
+NR == 1 {
+    split($0, DNA, //)
+    FPAT = "."
+    next
+}
+NR == 2 && NF != length(DNA) {
+    print "strands must be of equal length"
+    exit 1
+}
+NR == 2  {
+    for (i = NF; i; --i) distance += DNA[i] != $i
+    print +distance
+}

--- a/hamming/test-hamming.bats
+++ b/hamming/test-hamming.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+load bats-extra
+
+populate_test_file() {
+    echo "$1" > input.txt
+    echo "$2" >> input.txt
+}
+
+teardown() {
+    rm -f input.txt
+}
+
+@test 'empty strands' {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  populate_test_file '' ''
+  run gawk -f hamming.awk input.txt
+  assert_success
+  assert_output "0"
+}
+
+@test 'single letter identical strands' {
+  populate_test_file 'A' 'A'
+  run gawk -f hamming.awk input.txt
+  assert_success
+  assert_output "0"
+}
+
+@test 'single letter different strands' {
+  populate_test_file 'G' 'T'
+  run gawk -f hamming.awk input.txt
+  assert_success
+  assert_output "1"
+}
+
+@test 'long identical strands' {
+  populate_test_file 'GGACTGAAATCTG' 'GGACTGAAATCTG'
+  run gawk -f hamming.awk input.txt
+  assert_success
+  assert_output "0"
+}
+
+@test 'long different strands' {
+  populate_test_file 'GGACGGATTCTG' 'AGGACGGATTCT'
+  run gawk -f hamming.awk input.txt
+  assert_success
+  assert_output "9"
+}
+
+@test 'disallow first strand longer' {
+  populate_test_file 'AATG' 'AAA'
+  run gawk -f hamming.awk input.txt
+  assert_failure
+  assert_output --partial "strands must be of equal length"
+}
+
+@test 'disallow second strand longer' {
+  populate_test_file 'ATA' 'AGTG'
+  run gawk -f hamming.awk input.txt
+  assert_failure
+  assert_output --partial "strands must be of equal length"
+}
+
+@test 'disallow empty first strand' {
+  populate_test_file '' 'G'
+  run gawk -f hamming.awk input.txt
+  assert_failure
+  assert_output --partial "strands must be of equal length"
+}
+
+@test 'disallow empty second strand' {
+  populate_test_file 'G' ''
+  run gawk -f hamming.awk input.txt
+  assert_failure
+  assert_output --partial "strands must be of equal length"
+}


### PR DESCRIPTION
Added a new awk script for calculating the Hamming distance between two DNA strands. Accompanied by the script, a test file is also added using the Bats testing framework. Besides, included a README file providing instructions and background information. The script ensures that the strands are of equal length as the Hamming distance is only defined for equal length sequences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a tool to calculate the Hamming distance, which measures differences between two DNA strands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->