### PR TITLE
Add phone number cleaning functionality

### DIFF
--- a/phone-number/README.md
+++ b/phone-number/README.md
@@ -1,0 +1,34 @@
+# Description
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda.
+All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as _area code_, followed by a seven-digit local number.
+The first three digits of the local number represent the _exchange code_, followed by the unique four-digit number which is the _subscriber number_.
+
+The format is usually represented as
+
+```text
+NXX NXX-XXXX
+```
+
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Sometimes they also have the country code (represented as `1` or `+1`) prefixed.
+
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code if present.
+
+For example, the inputs
+
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.

--- a/phone-number/phone-number.awk
+++ b/phone-number/phone-number.awk
@@ -33,6 +33,6 @@ $4 == 1 {
     die("exchange code cannot start with one")
 }
 
-$1 {$1 = $1} 1
+{$1 = $1} 1
 
 function die(message) {print message > "/dev/stderr"; exit 1}

--- a/phone-number/phone-number.awk
+++ b/phone-number/phone-number.awk
@@ -1,0 +1,38 @@
+BEGIN {
+    FPAT = "[0-9]"
+    OFS = ""
+}
+/[[:alpha:]]/ {
+    die("letters not permitted")
+}
+/[@:!]/ {
+    die("punctuations not permitted")
+}
+NF < 10 {
+    die("must not be fewer than 10 digits")
+}
+NF > 11 {
+    die("must not be greater than 11 digits")
+}
+NF == 11 && $1 != "1" {
+    die("11 digits must start with 1")
+}
+NF == 11 && $1 == 1 {
+    $0 = gensub(/1/, "", 1)
+}
+$1 == 0 {
+    die("area code cannot start with zero")
+}
+$1 == 1 {
+    die("area code cannot start with one")
+}
+$4 == 0 {
+    die("exchange code cannot start with zero")
+}
+$4 == 1 {
+    die("exchange code cannot start with one")
+}
+
+$1 {$1 = $1} 1
+
+function die(message) {print message > "/dev/stderr"; exit 1}

--- a/phone-number/test-phone-number.bats
+++ b/phone-number/test-phone-number.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "cleans the number" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "(223) 456-7890"
+
+    assert_success
+    assert_output "2234567890"
+}
+
+@test "cleans numbers with dots" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "223.456.7890"
+
+    assert_success
+    assert_output "2234567890"
+}
+
+@test "cleans numbers with multiple spaces" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "223 456   7890   "
+
+    assert_success
+    assert_output "2234567890"
+}
+
+@test "invalid when 9 digits" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "123456789"
+
+    assert_failure
+    assert_output "must not be fewer than 10 digits"
+}
+
+@test "invalid when 11 digits does not start with a 1" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "22234567890"
+
+    assert_failure
+    assert_output "11 digits must start with 1"
+}
+
+@test "valid when 11 digits and starting with 1" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "12234567890"
+
+    assert_success
+    assert_output "2234567890"
+}
+
+@test "valid when 11 digits and starting with 1 even with punctuation" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "+1 (223) 456-7890"
+
+    assert_success
+    assert_output "2234567890"
+}
+
+@test "invalid when more than 11 digits" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "321234567890"
+
+    assert_failure
+    assert_output "must not be greater than 11 digits"
+}
+
+@test "invalid with letters" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "523-abc-7890"
+
+    assert_failure
+    assert_output "letters not permitted"
+}
+
+@test "invalid with punctuations" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "523-@:!-7890"
+
+    assert_failure
+    assert_output "punctuations not permitted"
+}
+
+@test "invalid if area code starts with 0" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "(023) 456-7890"
+
+    assert_failure
+    assert_output "area code cannot start with zero"
+}
+
+@test "invalid if area code starts with 1" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "(123) 456-7890"
+
+    assert_failure
+    assert_output "area code cannot start with one"
+}
+
+@test "invalid if exchange code starts with 0" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "(223) 056-7890"
+
+    assert_failure
+    assert_output "exchange code cannot start with zero"
+}
+
+@test "invalid if exchange code starts with 1" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "(223) 156-7890"
+
+    assert_failure
+    assert_output "exchange code cannot start with one"
+}
+
+@test "invalid if area code starts with 0 on valid 11-digit number" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "1 (023) 456-7890"
+
+    assert_failure
+    assert_output "area code cannot start with zero"
+}
+
+@test "invalid if area code starts with 1 on valid 11-digit number" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "1 (123) 456-7890"
+
+    assert_failure
+    assert_output "area code cannot start with one"
+}
+
+@test "invalid if exchange code starts with 0 on valid 11-digit number" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "1 (223) 056-7890"
+
+    assert_failure
+    assert_output "exchange code cannot start with zero"
+}
+
+@test "invalid if exchange code starts with 1 on valid 11-digit number" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f phone-number.awk <<< "1 (223) 156-7890"
+
+    assert_failure
+    assert_output "exchange code cannot start with one"
+}


### PR DESCRIPTION
This commit introduces a script and tests for a phone number cleaning feature. The script cleans user-entered phone numbers by removing punctuation and the country code, if present. A comprehensive set of tests is included to validate a wide range of possible inputs, enforcing allowed patterns and restrictions. The README file is updated with a detailed explanation on this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented phone number validation to ensure correct digit patterns and disallow letters and specific characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->