### PR TITLE
Add kindergarten garden exercise with test cases

### DIFF
--- a/kindergarten-garden/README.md
+++ b/kindergarten-garden/README.md
@@ -1,0 +1,73 @@
+# Kindergarten Garden
+
+Welcome to Kindergarten Garden on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a diagram, determine which plants each child in the kindergarten class is
+responsible for.
+
+The kindergarten class is learning about growing plants.
+The teacher thought it would be a good idea to give them actual seeds, plant them in actual dirt, and grow actual plants.
+
+They've chosen to grow grass, clover, radishes, and violets.
+
+To this end, the children have put little cups along the window sills, and
+planted one type of plant in each cup, choosing randomly from the available
+types of seeds.
+
+```text
+[window][window][window]
+........................ # each dot represents a cup
+........................
+```
+
+There are 12 children in the class:
+
+- Alice, Bob, Charlie, David,
+- Eve, Fred, Ginny, Harriet,
+- Ileana, Joseph, Kincaid, and Larry.
+
+Each child gets 4 cups, two on each row.
+Their teacher assigns cups to the children alphabetically by their names.
+
+The following diagram represents Alice's plants:
+
+```text
+[window][window][window]
+VR......................
+RG......................
+```
+
+In the first row, nearest the windows, she has a violet and a radish.
+In the second row she has a radish and some grass.
+
+Your program will be given the plants from left-to-right starting with the row nearest the windows.
+From this, it should be able to determine which plants belong to each student.
+
+For example, if it's told that the garden looks like so:
+
+```text
+[window][window][window]
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+```
+
+Then if asked for Alice's plants, it should provide:
+
+- Violets, radishes, violets, radishes
+
+While asking for Bob's plants would yield:
+
+- Clover, grass, clover, clover
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Exercise by the JumpstartLab team for students at The Turing School of Software and Design. - https://turing.edu

--- a/kindergarten-garden/kindergarten-garden.awk
+++ b/kindergarten-garden/kindergarten-garden.awk
@@ -1,0 +1,23 @@
+# These variables are initialized on the command line (using '-v'):
+# - name
+
+BEGIN {
+    ChildrensInitials = "ABCDEFGHIJKL"
+    Initial = substr(name, 1, 1)
+    Position = index(ChildrensInitials, Initial)
+
+    Plants["G"] = "grass"
+    Plants["R"] = "radishes"
+    Plants["C"] = "clover"
+    Plants["V"] = "violets"
+
+    ORS = ""
+    OFS = " "
+    FPAT = "[[:alpha:]]"
+}
+NR == 2 {
+    print " "
+}
+{
+    print Plants[$(Position * 2 - 1)], Plants[$(Position * 2)]
+}

--- a/kindergarten-garden/test-kindergarten-garden.bats
+++ b/kindergarten-garden/test-kindergarten-garden.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# partial garden
+
+@test "garden with single student" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Alice" << END_GARDEN
+RC
+GG
+END_GARDEN
+    assert_success
+    assert_output "radishes clover grass grass"
+}
+
+@test "different garden with single student" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Alice" << END_GARDEN
+VC
+RC
+END_GARDEN
+    assert_success
+    assert_output "violets clover radishes clover"
+}
+
+@test "garden with two students" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Bob" << END_GARDEN
+VVCG
+VVRC
+END_GARDEN
+    assert_success
+    assert_output "clover grass radishes clover"
+}
+
+@test "three students, second student's garden" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Bob" << END_GARDEN
+VVCCGG
+VVCCGG
+END_GARDEN
+    assert_success
+    assert_output "clover clover clover clover"
+}
+            
+@test "three students, third student's garden" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Charlie" << END_GARDEN
+VVCCGG
+VVCCGG
+END_GARDEN
+    assert_success
+    assert_output "grass grass grass grass"
+}
+
+# full garden
+
+@test "for Alice, first student's garden" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Alice" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "violets radishes violets radishes"
+}
+
+@test "for Bob, second student's garden" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Bob" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "clover grass clover clover"
+}
+
+@test "for Charlie" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Charlie" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "violets violets clover grass"
+}
+
+@test "for David" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="David" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "radishes violets clover radishes"
+}
+
+@test "for Eve" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Eve" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "clover grass radishes grass"
+}
+
+@test "for Fred" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Fred" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "grass clover violets clover"
+}
+
+@test "for Ginny" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Ginny" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "clover grass grass clover"
+}
+
+@test "for Harriet" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Harriet" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "violets radishes radishes violets"
+}
+
+@test "for Ileana" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Ileana" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "grass clover violets clover"
+}
+
+@test "for Joseph" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Joseph" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "violets clover violets grass"
+}
+
+@test "for Kincaid, second to last student's garden" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Kincaid" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "grass clover clover grass"
+}
+
+@test "for Larry, last student's garden" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f kindergarten-garden.awk -v name="Larry" << END_GARDEN
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+END_GARDEN
+    assert_success
+    assert_output "grass violets clover violets"
+}


### PR DESCRIPTION
This commit introduces a new exercise about kindergarteners and their plants, written in AWK. The included AWK script interprets the children's planting arrangement based on given data. Test cases to validate the functionality of the script and evaluate various scenarios are included alongside the problem's description in README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a garden layout feature where children's initials map to specific plants, enhancing the interactive learning experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->