### PR TITLE
Add proverb.awk script and corresponding tests

### DIFF
--- a/proverb/proverb.awk
+++ b/proverb/proverb.awk
@@ -1,0 +1,7 @@
+{
+    for (i = 1; i < NF; i++)
+        print "For want of a " $i " the " $(i + 1) " was lost."
+}
+NF > 0 {
+    print "And all for the want of a " $1 "."
+}

--- a/proverb/test-proverb.bats
+++ b/proverb/test-proverb.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "zero pieces" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f proverb.awk <<< ""
+
+    assert_success
+    assert_equal "${#lines[@]}" 0
+}
+
+@test "one piece" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f proverb.awk <<< "nail"
+
+    assert_success
+    assert_line --index 0 -- "And all for the want of a nail."
+    assert_equal "${#lines[@]}" 1
+}
+
+@test "two pieces" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f proverb.awk <<< "nail shoe"
+
+    assert_success
+    assert_line --index 0 -- "For want of a nail the shoe was lost."
+    assert_line --index 1 -- "And all for the want of a nail."
+    assert_equal "${#lines[@]}" 2
+}
+
+@test "three pieces" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f proverb.awk <<< "nail shoe horse"
+
+    assert_success
+    assert_line --index 0 -- "For want of a nail the shoe was lost."
+    assert_line --index 1 -- "For want of a shoe the horse was lost."
+    assert_line --index 2 -- "And all for the want of a nail."
+    assert_equal "${#lines[@]}" 3
+}
+
+@test "full proverb" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f proverb.awk <<< "nail shoe horse rider message battle kingdom"
+
+    assert_success
+    assert_line --index 0 -- "For want of a nail the shoe was lost."
+    assert_line --index 1 -- "For want of a shoe the horse was lost."
+    assert_line --index 2 -- "For want of a horse the rider was lost."
+    assert_line --index 3 -- "For want of a rider the message was lost."
+    assert_line --index 4 -- "For want of a message the battle was lost."
+    assert_line --index 5 -- "For want of a battle the kingdom was lost."
+    assert_line --index 6 -- "And all for the want of a nail."
+    assert_equal "${#lines[@]}" 7
+}
+
+@test "four pieces modernized" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f proverb.awk <<< "pin gun soldier battle"
+
+    assert_success
+    assert_line --index 0 -- "For want of a pin the gun was lost."
+    assert_line --index 1 -- "For want of a gun the soldier was lost."
+    assert_line --index 2 -- "For want of a soldier the battle was lost."
+    assert_line --index 3 -- "And all for the want of a pin."
+    assert_equal "${#lines[@]}" 4
+}


### PR DESCRIPTION
This commit introduces a new Awk script, 'proverb.awk', that prints out a proverb based on provided input. The committed code also includes a set of bats tests, 'test-proverb.bats', to assert the correct functioning and output of this script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature that generates proverbial outputs to highlight the consequences of missing elements in sequences based on user inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->