### PR TITLE
Add largest series product functionality and tests

### DIFF
--- a/largest-series-product/README.md
+++ b/largest-series-product/README.md
@@ -1,0 +1,29 @@
+# Largest Series Product
+
+Welcome to Largest Series Product on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a series of 3 digits is 270 `(9 * 5 * 6)`, and the largest product for a series of 5 digits is 7560 `(7 * 8 * 3 * 9 * 5)`.
+
+Note that these series are only required to occupy *adjacent positions* in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+For a series of zero digits, the largest product is 1 because 1 is the multiplicative identity.
+(You don't need to know what a multiplicative identity is to solve this problem;
+it just means that multiplying a number by 1 gives you the same number.)
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+A variation on Problem 8 at Project Euler - https://projecteuler.net/problem=8

--- a/largest-series-product/largest-series-product.awk
+++ b/largest-series-product/largest-series-product.awk
@@ -1,0 +1,27 @@
+BEGIN {
+    FS=","
+}
+length($1) < $2 {die("span must be smaller than string length")}
+$1 ~ /[^[:digit:]]/ {die("input must only contain digits")}
+$2 < 0 {die("span must not be negative")}
+!$2 {print 1; next}
+
+{
+    print largest_product()
+}
+
+function product(number,   digits,result,i) {
+    split(number, digits, //)
+    result = 1
+    for (i in digits) result *= digits[i]
+    return result
+}
+function largest_product(   i,number,mp) {
+    for (i = length($1) - $2 + 1; i > 0; --i) {
+        number = substr($1, i, $2)
+        mp = max(mp, product(number))
+    }
+    return +mp
+}
+function die(message) {print message > "/dev/stderr"; exit 1}
+function max(a, b) {return a > b ? a : b}

--- a/largest-series-product/test-largest-series-product.bats
+++ b/largest-series-product/test-largest-series-product.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+load bats-extra
+
+@test "finds the largest product if span equals length" {
+    #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run gawk -f largest-series-product.awk <<< "29,2"
+    assert_success
+    assert_output "18"
+}
+
+@test "can find the largest product of 2 with numbers in order" {
+    run gawk -f largest-series-product.awk <<< "0123456789,2"
+    assert_success
+    assert_output "72"
+}
+
+@test "can find the largest product of 2" {
+    run gawk -f largest-series-product.awk <<< "576802143,2"
+    assert_success
+    assert_output "48"
+}
+
+@test "can find the largest product of 3 with numbers in order" {
+    run gawk -f largest-series-product.awk <<< "0123456789,3"
+    assert_success
+    assert_output "504"
+}
+
+@test "can find the largest product of 3" {
+    run gawk -f largest-series-product.awk <<< "1027839564,3"
+    assert_success
+    assert_output "270"
+}
+
+@test "can find the largest product of 5 with numbers in order" {
+    run gawk -f largest-series-product.awk <<< "0123456789,5"
+    assert_success
+    assert_output "15120"
+}
+
+@test "can get the largest product of a big number" {
+    run gawk -f largest-series-product.awk <<< "73167176531330624919225119674426574742355349194934,6"
+    assert_success
+    assert_output "23520"
+}
+
+@test "reports zero if the only digits are zero" {
+    run gawk -f largest-series-product.awk <<< "0000,2"
+    assert_success
+    assert_output "0"
+}
+
+@test "reports zero if all spans include zero" {
+    run gawk -f largest-series-product.awk <<< "99099,3"
+    assert_success
+    assert_output "0"
+}
+
+# There may be some confusion about whether this should be 1 or error.
+# The reasoning for it being 1 is this:
+# There is one 0-character string contained in the empty string.
+# That's the empty string itself.
+# The empty product is 1 (the identity for multiplication).
+# Therefore LSP('', 0) is 1.
+# It's NOT the case that LSP('', 0) takes max of an empty list.
+# So there is no error.
+# Compare against LSP('123', 4):
+# There are zero 4-character strings in '123'.
+# So LSP('123', 4) really DOES take the max of an empty list.
+# So LSP('123', 4) errors and LSP('', 0) does NOT.
+
+@test "reports 1 for empty string and empty product (0 span)" {
+    run gawk -f largest-series-product.awk <<< ",0"
+    assert_success
+    assert_output "1"
+}
+
+# As above, there is one 0-character string in '123'.
+# So again no error. It's the empty product, 1.
+
+@test "reports 1 for nonempty string and empty product (0 span)" {
+    run gawk -f largest-series-product.awk <<< "123,0"
+    assert_success
+    assert_output "1"
+}
+
+# error cases
+
+@test "rejects span longer than string length" {
+    run gawk -f largest-series-product.awk <<< "123,4"
+    assert_failure
+    assert_output --partial "span must be smaller than string length"
+}
+
+@test "rejects empty string and nonzero span" {
+    run gawk -f largest-series-product.awk <<< ",1"
+    assert_failure
+    assert_output --partial "span must be smaller than string length"
+}
+
+@test "rejects invalid character in digits" {
+    run gawk -f largest-series-product.awk <<< "1234a5,2"
+    assert_failure
+    assert_output --partial "input must only contain digits"
+}
+
+@test "rejects negative span" {
+    run gawk -f largest-series-product.awk <<< "12345,-1"
+    assert_failure
+    assert_output --partial "span must not be negative"
+}


### PR DESCRIPTION
This commit introduces a new AWK script to calculate the largest product from a series of digits, given a string of digits and the number of contiguous digits to consider. Tests have also been created to verify this functionality. The largest product is calculated considering all possible combinations of digits, and is capable of handling edge cases such as zero digits, only digits are zero, and spans including zero. Error conditions are also defined and tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new tool to calculate the largest product of a series of digits efficiently, ensuring input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->